### PR TITLE
fix: all_with_deleted filter when used on a related manager.

### DIFF
--- a/safedelete/managers.py
+++ b/safedelete/managers.py
@@ -38,7 +38,20 @@ def safedelete_manager_factory(manager_superclass, queryset_superclass, visibili
 
         def all_with_deleted(self):
             """ Return a queryset to every objects, including deleted ones. """
-            return SafeDeleteQueryset(self.model, using=self._db)
+            queryset = SafeDeleteQueryset(self.model, using=self._db)
+            if hasattr(self, 'core_filters'):
+                # In a RelatedManager, must filter and add hints
+                if hasattr(queryset, '_add_hints'):
+                    # Django >= 1.7
+                    queryset._add_hints(instance=self.instance)
+                queryset = queryset.filter(**self.core_filters)
+                # FIXME: How to get rel_field ?
+                # if hasattr(queryset, '_known_related_objects'):
+                #     # Django >= 1.5
+                #     queryset._known_related_objects = {
+                #         rel_field: {self.instance.pk: self.instance}
+                #     }
+            return queryset
 
         def deleted_only(self):
             """ Return a queryset to only deleted objects. """

--- a/safedelete/tests.py
+++ b/safedelete/tests.py
@@ -190,6 +190,17 @@ class SimpleTest(TestCase):
 
         self.assertEqual(Category.objects.count(), 3)
 
+    def test_related_manager(self):
+        order = Order.objects.create(name='order 2')
+        Order.objects.create(name='order 3')
+        order.articles.add(self.articles[0])
+        self.assertEqual(self.articles[0].order_set.all().count(), 2)
+        order.delete()
+        self.assertEqual(self.articles[0].order_set.all().count(), 1)
+        self.assertEqual(
+            self.articles[0].order_set.all_with_deleted().count(), 2
+        )
+
     def test_validate_unique(self):
         """ Check that uniqueness is also checked against deleted objects """
         Category.objects.create(name='test').delete()


### PR DESCRIPTION
`all_with_deleted` creates a new queryset, and thus remove the filter from the RelatedManager.

See https://github.com/django/django/blob/master/django/db/models/fields/related.py#L688 for when it is done in Django.

A test has been added.

Still missing: `queryset._known_related_objects`. We apparently can't get the `rel_field` trivially. Does someone have a way to get it ?
