### PR TITLE
Move SoftDeleteMixin into a separate module

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -13,7 +13,7 @@ You can create this abstract model by calling the function :py:func:`safedelete_
 
 There is also a shortcut available if you want to have simple soft-deletable objects :
 
-.. py:data:: SoftDeleteMixin
+.. py:data:: safedelete.shortcuts.SoftDeleteMixin
 
     This is a ready-to-use base model, obtained by calling ``safedelete_mixin_factory(SOFT_DELETE)``.
 

--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -121,7 +121,3 @@ def safedelete_mixin_factory(policy,
             return errors
 
     return Model
-
-
-# Often used
-SoftDeleteMixin = safedelete_mixin_factory(SOFT_DELETE)

--- a/safedelete/shortcuts.py
+++ b/safedelete/shortcuts.py
@@ -1,0 +1,5 @@
+from .models import safedelete_mixin_factory
+from .utils import SOFT_DELETE
+
+
+SoftDeleteMixin = safedelete_mixin_factory(SOFT_DELETE)

--- a/safedelete/tests.py
+++ b/safedelete/tests.py
@@ -9,9 +9,10 @@ from django.db import models
 from django.test import TestCase, RequestFactory
 
 from .admin import SafeDeleteAdmin, highlight_deleted
-from .models import (safedelete_mixin_factory, SoftDeleteMixin,
-                     HARD_DELETE, HARD_DELETE_NOCASCADE, SOFT_DELETE,
-                     NO_DELETE, DELETED_VISIBLE_BY_PK)
+from .models import (safedelete_mixin_factory, HARD_DELETE,
+                     HARD_DELETE_NOCASCADE, SOFT_DELETE, NO_DELETE,
+                     DELETED_VISIBLE_BY_PK)
+from .shortcuts import SoftDeleteMixin
 
 
 # MODELS (FOR TESTING)


### PR DESCRIPTION
One possible solution to ensure compatibility with future Django versions. Unfortunately, it's not backwards-compatible (but it's trivial to adjust client code to the change).

I am not sure if there is a better way to fix this. More investigation may be needed.