### PR TITLE
Adds support for Django 1.8 and 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - DJANGO_VERSION=1.5
   - DJANGO_VERSION=1.6
   - DJANGO_VERSION=1.7
+  - DJANGO_VERSION=1.8
 
 install: 
    # This is a dependency of our Django test script
@@ -55,4 +56,6 @@ matrix:
           env: DJANGO_VERSION=1.6
         - python: 2.6
           env: DJANGO_VERSION=1.7
+        - python: 2.6
+          env: DJANGO_VERSION=1.8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ after_success:
 
 # We need to exclude old versions of Django for tests with python 3.
 # We need to exclude old versions of Python for tests with Django >= 1.7.
+# 1.9: Dropped support for 3.2-3.3: https://docs.djangoproject.com/en/dev/releases/1.9/#python-compatibility
 matrix:
     exclude:
         - python: 3.2
@@ -62,5 +63,9 @@ matrix:
         - python: 2.6
           env: DJANGO_VERSION="stable/1.8.x"
         - python: 2.6
+          env: DJANGO_VERSION="master"
+        - python: 3.2
+          env: DJANGO_VERSION="master"
+        - python: 3.3
           env: DJANGO_VERSION="master"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,12 @@ python:
   - 3.4
 
 env:
-  - DJANGO_VERSION=1.4
-  - DJANGO_VERSION=1.5
-  - DJANGO_VERSION=1.6
-  - DJANGO_VERSION=1.7
-  - DJANGO_VERSION=1.8
+  - DJANGO_VERSION="stable/1.4.x"
+  - DJANGO_VERSION="stable/1.5.x"
+  - DJANGO_VERSION="stable/1.6.x"
+  - DJANGO_VERSION="stable/1.7.x"
+  - DJANGO_VERSION="stable/1.8.x"
+  - DJANGO_VERSION="master" # 1.9
 
 install: 
    # This is a dependency of our Django test script
@@ -21,7 +22,9 @@ install:
    # Install the dependencies of the app itself
    # - pip install -r requirements.txt --use-mirrors
 
- - pip install -q Django==$DJANGO_VERSION --use-mirrors
+   # Clone Django from the GitHub repository
+ - git clone -b $DJANGO_VERSION --single-branch https://github.com/django/django
+ - pip install -e django/
 
  - pip install coverage
 
@@ -45,17 +48,19 @@ after_success:
 matrix:
     exclude:
         - python: 3.2
-          env: DJANGO_VERSION=1.4
+          env: DJANGO_VERSION="stable/1.4.x"
         - python: 3.3
-          env: DJANGO_VERSION=1.4
+          env: DJANGO_VERSION="stable/1.4.x"
         - python: 3.4
-          env: DJANGO_VERSION=1.4
+          env: DJANGO_VERSION="stable/1.4.x"
         - python: 3.4
-          env: DJANGO_VERSION=1.5
+          env: DJANGO_VERSION="stable/1.5.x"
         - python: 3.4
-          env: DJANGO_VERSION=1.6
+          env: DJANGO_VERSION="stable/1.6.x"
         - python: 2.6
-          env: DJANGO_VERSION=1.7
+          env: DJANGO_VERSION="stable/1.7.x"
         - python: 2.6
-          env: DJANGO_VERSION=1.8
+          env: DJANGO_VERSION="stable/1.8.x"
+        - python: 2.6
+          env: DJANGO_VERSION="master"
 

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,9 @@ Current branch (0.3.x) has been tested with :
 *  Django 1.4, using python 2.6 and 2.7.
 *  Django 1.5 and 1.6, using python 2.6, 2.7 and 3.x.
 *  Django 1.7 using python 2.7 and python 3.x.
+*  Django 1.8 using python 2.7 and python 3.x.
+*  Django 1.9dev using python 2.7 and python 3.4.
+
 
 
 Installation

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -13,7 +13,7 @@ You can create this abstract model by calling the function :py:func:`safedelete_
 
 There is also a shortcut available if you want to have simple soft-deletable objects :
 
-.. py:data:: SoftDeleteMixin
+.. py:data:: safedelete.shortcuts.SoftDeleteMixin
 
     This is a ready-to-use base model, obtained by calling ``safedelete_mixin_factory(SOFT_DELETE)``.
 

--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -1,4 +1,6 @@
+from distutils.version import LooseVersion
 from django.db import models
+import django
 
 from .managers import safedelete_manager_factory
 from .utils import (related_objects,
@@ -121,3 +123,7 @@ def safedelete_mixin_factory(policy,
             return errors
 
     return Model
+
+# Maintains retro-compatibility with older versions, which use Django 1.9
+if LooseVersion(django.get_version()) < LooseVersion('1.9'):
+    SoftDeleteMixin = safedelete_mixin_factory(SOFT_DELETE)

--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -121,7 +121,3 @@ def safedelete_mixin_factory(policy,
             return errors
 
     return Model
-
-
-# Often used
-SoftDeleteMixin = safedelete_mixin_factory(SOFT_DELETE)

--- a/safedelete/shortcuts.py
+++ b/safedelete/shortcuts.py
@@ -1,0 +1,5 @@
+from .models import safedelete_mixin_factory
+from .utils import SOFT_DELETE
+
+
+SoftDeleteMixin = safedelete_mixin_factory(SOFT_DELETE)

--- a/safedelete/tests.py
+++ b/safedelete/tests.py
@@ -9,9 +9,10 @@ from django.db import models
 from django.test import TestCase, RequestFactory
 
 from .admin import SafeDeleteAdmin, highlight_deleted
-from .models import (safedelete_mixin_factory, SoftDeleteMixin,
-                     HARD_DELETE, HARD_DELETE_NOCASCADE, SOFT_DELETE,
-                     NO_DELETE, DELETED_VISIBLE_BY_PK)
+from .models import (safedelete_mixin_factory, HARD_DELETE,
+                     HARD_DELETE_NOCASCADE, SOFT_DELETE, NO_DELETE,
+                     DELETED_VISIBLE_BY_PK)
+from .shortcuts import SoftDeleteMixin
 
 
 # MODELS (FOR TESTING)

--- a/safedelete/tests.py
+++ b/safedelete/tests.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 import django
 from django.conf.urls import patterns, include
 from django.core.exceptions import ValidationError
@@ -12,7 +13,11 @@ from .admin import SafeDeleteAdmin, highlight_deleted
 from .models import (safedelete_mixin_factory, HARD_DELETE,
                      HARD_DELETE_NOCASCADE, SOFT_DELETE, NO_DELETE,
                      DELETED_VISIBLE_BY_PK)
-from .shortcuts import SoftDeleteMixin
+
+if LooseVersion(django.get_version()) < LooseVersion('1.9'):
+    from .models import SoftDeleteMixin
+else:
+    from .shortcuts import SoftDeleteMixin
 
 
 # MODELS (FOR TESTING)


### PR DESCRIPTION
Today I realised my project needed to support Django 1.9 but it wasn't yet ready only because of django-safedelete. Then I noticed #35 and I decided to try and finish the job.

* Enables Travis testing on Django 1.8 and Django 1.9 with the respective supported python versions. This is done by using git to clone the GitHub "stable/1.x.y" and "master" branches of [Django](https://github.com/django/django), together with pip.
* Includes b450f3f034dc8739c49d475a09b059415de25d26 by @rfleschenberg, which adds support for Django 1.9
  * Fixed to maintain `SoftDeleteMixin` retro-compatibility, as suggested by @Gagaro in #35 + tests
* Updates the README to include compatibility statements for Django 1.8 and 1.9.

Tests pass on Travis for all versions of Django up to 1.9: https://travis-ci.org/AlfioEmanueleFresta/django-safedelete