### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ The application doesn't have any special requirement.
 Documentation
 -------------
 
-The documentation is available `here <http://django-safedelete.readthedocs.org>`_.
+The documentation is available `here <https://django-safedelete.readthedocs.io>`_.
 
 
 Licensing


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.