### PR TITLE
adding a pre_softdelete signal

### DIFF
--- a/safedelete/signals.py
+++ b/safedelete/signals.py
@@ -1,4 +1,5 @@
 from django.db.models.signals import ModelSignal
 
+pre_softdelete = ModelSignal(providing_args=["instance", "using"], use_caching=True)
 post_softdelete = ModelSignal(providing_args=["instance", "using"], use_caching=True)
 post_undelete = ModelSignal(providing_args=["instance", "using"], use_caching=True)

--- a/safedelete/tests/test_soft_delete.py
+++ b/safedelete/tests/test_soft_delete.py
@@ -34,11 +34,17 @@ class SoftDeleteTestCase(SafeDeleteForceTestCase):
 
     @mock.patch('safedelete.models.post_undelete.send')
     @mock.patch('safedelete.models.post_softdelete.send')
-    def test_signals(self, mock_softdelete, mock_undelete):
+    @mock.patch('safedelete.models.pre_softdelete.send')
+    def test_signals(self, mock_presoftdelete, mock_softdelete, mock_undelete):
         """The soft delete and undelete signals should be sent correctly for soft deleted models."""
         self.instance.delete()
 
-        # Soft deleting the model should've sent a post_softdelete signal.
+        # Soft deleting the model should've sent a pre_softdelete and a post_softdelete signals.
+        self.assertEqual(
+            mock_presoftdelete.call_count,
+            1
+        )
+
         self.assertEqual(
             mock_softdelete.call_count,
             1


### PR DESCRIPTION
I am going to reopen this pull request, just rebased.

> 
> I think that it is useful to have also the pre_softdelete signal, since it can be used to validate some conditions and raise Exceptions to avoid the safe delete of some objects.
> 
> I needed the feature and already implemented it, so you can test and accept the change upstream if you wish. I hope the code is under the quality criteria of the project.

Thanks you in advance
