### PR TITLE
Add custom qs hooks

### DIFF
--- a/safedelete/managers.py
+++ b/safedelete/managers.py
@@ -84,3 +84,20 @@ class SafeDeleteManager(models.Manager):
         if self._safedelete_visibility == DELETED_VISIBLE_BY_FIELD and self._safedelete_visibility_field in kwargs:
             return self.all_with_deleted().get(*args, **kwargs)
         return self.get_queryset().get(*args, **kwargs)
+
+    def __init__(self, queryset_class=None, *args, **kwargs):
+        """Hook for setting custom ``_queryset_class``
+
+        Example:
+
+            class CustomQueryset(models.QuerySet):
+                pass
+
+            class MyModel(models.Model):
+                my_field = models.TextField()
+
+                objects = SafeDeleteManager(CustomQuerySet)
+        """
+        super(SafeDeleteManager, self).__init__(*args, **kwargs)
+        if queryset_class:
+            self._queryset_class = queryset_class

--- a/safedelete/managers.py
+++ b/safedelete/managers.py
@@ -28,7 +28,7 @@ class SafeDeleteManager(models.Manager):
     If _safedelete_visibility == DELETED_VISIBLE_BY_PK, the manager can returns deleted
     objects if they are accessed by primary key.
 
-     :attribute _safedelete_visibility: define what happens when you query masked objects.
+    :attribute _safedelete_visibility: define what happens when you query masked objects.
         It can be one of ``DELETED_INVISIBLE`` and ``DELETED_VISIBLE_BY_PK``.
         Defaults to ``SOFT_DELETE``.
 
@@ -43,21 +43,27 @@ class SafeDeleteManager(models.Manager):
         ...     objects = MyModelManager()
         ...
         >>>
+
+    :attribute _queryset_class: define which class for queryset should be used
+        This attribute allows to add custom filters for both deleted and not
+        deleted objects. It is ``SafeDeleteQueryset`` by default.
+        Custom queryset classes should be inherited from ``SafeDeleteQueryset``
     """
 
     _safedelete_visibility = DELETED_INVISIBLE
     _safedelete_visibility_field = 'pk'
+    _queryset_class = SafeDeleteQueryset
 
     def get_queryset(self):
         # We MUST NOT do the core_filters in get_queryset.
         # The child *RelatedManager will take care of that.
         # It will break prefetch_related if we do it here.
-        queryset = SafeDeleteQueryset(self.model, using=self._db)
+        queryset = self._queryset_class(self.model, using=self._db)
         return queryset.filter(deleted__isnull=True)
 
     def all_with_deleted(self):
         """ Return a queryset to every objects, including deleted ones. """
-        queryset = SafeDeleteQueryset(self.model, using=self._db)
+        queryset = self._queryset_class(self.model, using=self._db)
         # We need to filter if we are in a RelatedManager. See the `test_related_manager`.
         if hasattr(self, 'core_filters'):
             # In a RelatedManager, must filter and add hints

--- a/safedelete/tests/test_custom_queryset.py
+++ b/safedelete/tests/test_custom_queryset.py
@@ -14,12 +14,11 @@ class CustomQuerySet(SafeDeleteQueryset):
 
 
 class CustomManager(SafeDeleteManager):
-
-    def get_queryset(self):
-        queryset = CustomQuerySet(self.model, using=self._db)
-        return queryset.filter(deleted__isnull=True)
+    _queryset_class = CustomQuerySet
 
     def green(self):
+        """Implemented here so ``green`` available as manager's method
+        """
         return self.get_queryset().green()
 
 

--- a/safedelete/tests/test_custom_queryset.py
+++ b/safedelete/tests/test_custom_queryset.py
@@ -36,6 +36,9 @@ class CustomQuerySetModel(SafeDeleteMixin):
 
     objects = CustomManager()
 
+    # other manager to test custom QS using ``SafeDeleteManager.__init__``
+    other_objects = SafeDeleteManager(CustomQuerySet)
+
 
 class CustomQuerySetTestCase(SafeDeleteTestCase):
 
@@ -53,7 +56,7 @@ class CustomQuerySetTestCase(SafeDeleteTestCase):
 
     def test_custom_queryset_custom_method(self):
         """Test custom filters for deleted objects"""
-        instance = CustomQuerySetModel.objects.create(color=choices[1][0])
+        instance = self._create_green_instance()
         instance.delete()
 
         deleted_only = CustomQuerySetModel.objects.deleted_only()
@@ -63,3 +66,24 @@ class CustomQuerySetTestCase(SafeDeleteTestCase):
 
         # and they can be custom filtered
         self.assertEqual(deleted_only.green().count(), 1)
+
+    def test_custom_queryset_without_manager(self):
+        """Test whether custom queryset may be used without custom manager
+        """
+        instance = self._create_green_instance()
+        instance.delete()
+
+        # note that ``other_objects`` manager used
+        deleted_only = CustomQuerySetModel.other_objects.deleted_only()
+
+        # ensure deleted instances available
+        self.assertEqual(deleted_only.count(), 1)
+
+        # and they can be custom filtered
+        self.assertEqual(deleted_only.green().count(), 1)
+
+    @staticmethod
+    def _create_green_instance():
+        """Shortcut for creating instance with ``color == green``
+        """
+        return CustomQuerySetModel.objects.create(color=choices[1][0])

--- a/safedelete/tests/test_custom_queryset.py
+++ b/safedelete/tests/test_custom_queryset.py
@@ -51,3 +51,16 @@ class CustomQuerySetTestCase(SafeDeleteTestCase):
 
         self.assertEqual(CustomQuerySetModel.objects.count(), 2)
         self.assertEqual(CustomQuerySetModel.objects.green().count(), 1)
+
+    def test_custom_queryset_custom_method(self):
+        """Test custom filters for deleted objects"""
+        instance = CustomQuerySetModel.objects.create(color=choices[1][0])
+        instance.delete()
+
+        deleted_only = CustomQuerySetModel.objects.deleted_only()
+
+        # ensure deleted instances available
+        self.assertEqual(deleted_only.count(), 1)
+
+        # and they can be custom filtered
+        self.assertEqual(deleted_only.green().count(), 1)


### PR DESCRIPTION
Added few hooks to use custom query set for safe delete models.

Previously you should:
* Create custom QS class (inherited from ``SafeDeleteQueryset``)
* Create custom manager class:
    - Inherited from ``SafeDeleteManager``
    - implementeed methods ``get_queryset``, ``all_with_deleted``
* use ``objects = CustomManager()``

Now you may simple:
* Create custom QS class (inherited from ``SafeDeleteQueryset``)
* use ``objects = SafeDeleteManager(CustomQuerySet)``