### PR TITLE
Safedelete m2m field

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -90,3 +90,14 @@ Sent after an object has been soft deleted.
 .. py:data:: safedelete.signals.post_undelete
 
 Sent after a deleted object is restored.
+
+
+Fields
+------
+
+When you use custom ``through`` model for M2M relations, you may want
+that related manager return only not-deleted relations. If so, you may want
+to use ``safedelete.fields.SafeDeleteManyToManyField``.
+
+You still will be able to retrieve deleted instances for intermediate model using
+it's manager.

--- a/safedelete/fields.py
+++ b/safedelete/fields.py
@@ -33,7 +33,9 @@ class SafeDeleteManyToManyField(models.ManyToManyField):
 
     def contribute_to_class(self, cls, name, **kwargs):
         """Add custom descriptor to source model"""
-        super().contribute_to_class(cls, name, **kwargs)
+        super(SafeDeleteManyToManyField, self).contribute_to_class(
+            cls, name, **kwargs
+        )
         setattr(
             cls,
             self.name,
@@ -42,7 +44,9 @@ class SafeDeleteManyToManyField(models.ManyToManyField):
 
     def contribute_to_related_class(self, cls, related):
         """Add custom descriptor to related model"""
-        super().contribute_to_related_class(cls, related)
+        super(SafeDeleteManyToManyField, self).contribute_to_related_class(
+            cls, related
+        )
         # this check is copied from django sources
         if not (self.remote_field.is_hidden() and
                 not related.related_model._meta.swapped):
@@ -62,14 +66,14 @@ class SafeDeleteManyToManyDescriptor(ManyToManyDescriptor):
     @cached_property
     def related_manager_cls(self):
         """Patch default relateed manager with custom filter"""
-        cls = super().related_manager_cls
+        cls = super(SafeDeleteManyToManyDescriptor, self).related_manager_cls
 
         class SafeDeleteRelatedManager(cls):
             """Related manager with custom filtration for soft-delete"""
 
             def _apply_rel_filters(self, queryset):
                 """Filter queryset for not deleted instances"""
-                queryset = super()._apply_rel_filters(queryset)
+                queryset = super(SafeDeleteRelatedManager, self)._apply_rel_filters(queryset)
                 return queryset.filter(**self._get_safedelete_filter())
 
             def _get_safedelete_filter(self):

--- a/safedelete/fields.py
+++ b/safedelete/fields.py
@@ -1,0 +1,85 @@
+from django.db import models
+from django.db.models.fields.related_descriptors import ManyToManyDescriptor
+from django.utils.functional import cached_property
+
+__all__ = ['SafeDeleteManyToManyField']
+
+
+class SafeDeleteManyToManyField(models.ManyToManyField):
+    """ManyToMany field that should be used with softdeletable through model
+
+    Checkout models in ``test_many2many_intermediate.py``
+    (``Person``, ``Group``, ``Membership``).
+    ``Membership`` model may be soft-deleted, and without using this field
+    this code will work incorrect:
+
+        group = Group.objects.create(name='Cool band')
+        person = Person.objects.create(name='Great singer')
+        membership = Membership.objects.create(
+            person=person,
+            group=group,
+            invite_reason='Need a new drummer'
+        )
+        membership.delete()
+        assert group.members.count() == 0
+
+    By default, descriptor of M2M field return all objects of related model,
+    filtered just by instance (i.e. return all ``Person`` matching ``group``).
+
+    This field just contribute special descriptor
+    ``SafeDeleteManyToManyDescriptor`` that add filtration for not-deleted
+    relation
+    """
+
+    def contribute_to_class(self, cls, name, **kwargs):
+        """Add custom descriptor to source model"""
+        super().contribute_to_class(cls, name, **kwargs)
+        setattr(
+            cls,
+            self.name,
+            SafeDeleteManyToManyDescriptor(self.remote_field, reverse=False)
+        )
+
+    def contribute_to_related_class(self, cls, related):
+        """Add custom descriptor to related model"""
+        super().contribute_to_related_class(cls, related)
+        # this check is copied from django sources
+        if not (self.remote_field.is_hidden() and
+                not related.related_model._meta.swapped):
+            setattr(
+                cls,
+                related.get_accessor_name(),
+                SafeDeleteManyToManyDescriptor(self.remote_field, reverse=True)
+            )
+
+
+class SafeDeleteManyToManyDescriptor(ManyToManyDescriptor):
+    """Custom descriptor that just change ``related_manager_cls``.
+
+    See docstring of ``SafeDeleteManyToManyField``
+    """
+
+    @cached_property
+    def related_manager_cls(self):
+        """Patch default relateed manager with custom filter"""
+        cls = super().related_manager_cls
+
+        class SafeDeleteRelatedManager(cls):
+            """Related manager with custom filtration for soft-delete"""
+
+            def _apply_rel_filters(self, queryset):
+                """Filter queryset for not deleted instances"""
+                queryset = super()._apply_rel_filters(queryset)
+                return queryset.filter(**self._get_safedelete_filter())
+
+            def _get_safedelete_filter(self):
+                """Build related filter dict
+
+                Example:
+                    {'membership__deleted__isnull': True}
+                """
+                field_name = self.target_field.related_query_name()
+                filter_key = '{}__deleted__isnull'.format(field_name)
+                return {filter_key: True}
+
+        return SafeDeleteRelatedManager

--- a/safedelete/tests/test_many2many_intermediate.py
+++ b/safedelete/tests/test_many2many_intermediate.py
@@ -4,6 +4,7 @@ relationships
 from django.db import models
 
 from ..models import SafeDeleteMixin
+from ..fields import SafeDeleteManyToManyField
 from .testcase import SafeDeleteTestCase
 
 
@@ -13,7 +14,7 @@ class Person(models.Model):
 
 class Group(models.Model):
     name = models.CharField(max_length=128)
-    members = models.ManyToManyField(Person, through='Membership')
+    members = SafeDeleteManyToManyField(Person, through='Membership')
 
 
 # Note: this model is safe deletable

--- a/safedelete/tests/test_many2many_intermediate.py
+++ b/safedelete/tests/test_many2many_intermediate.py
@@ -1,0 +1,48 @@
+"""These test uses models for django's example for extra fields on many to many
+relationships
+"""
+from django.db import models
+
+from ..models import SafeDeleteMixin
+from .testcase import SafeDeleteTestCase
+
+
+class Person(models.Model):
+    name = models.CharField(max_length=128)
+
+
+class Group(models.Model):
+    name = models.CharField(max_length=128)
+    members = models.ManyToManyField(Person, through='Membership')
+
+
+# Note: this model is safe deletable
+class Membership(SafeDeleteMixin):
+    person = models.ForeignKey(Person, on_delete=models.CASCADE)
+    group = models.ForeignKey(Group, on_delete=models.CASCADE)
+    invite_reason = models.CharField(max_length=64)
+
+
+class ManyToManyIntermediateTestCase(SafeDeleteTestCase):
+
+    def test_many_to_many_with_intermediate(self):
+        person = Person.objects.create(name='Great singer')
+        group = Group.objects.create(name='Cool band')
+
+        # can't use group.members.add() with intermediate model
+        membership = Membership.objects.create(
+            person=person,
+            group=group,
+            invite_reason='Need a new drummer'
+        )
+
+        # group members visible now
+        self.assertEqual(group.members.count(), 1)
+
+        # soft-delete intermediate instance
+        # so link should be invisible
+        membership.delete()
+        self.assertEqual(Membership.objects.deleted_only().count(), 1)
+
+        self.assertEqual(group.members.count(), 0)
+        self.assertEqual(person.group_set.count(), 0)


### PR DESCRIPTION
Checkout models in ``test_many2many_intermediate.py`` (``Person``, ``Group``, ``Membership``) or in [django docs](https://docs.djangoproject.com/en/1.10/topics/db/models/#extra-fields-on-many-to-many-relationships).
``Membership`` model may be soft-deleted, and without using this field this code will work incorrect:
```
group = Group.objects.create(name='Cool band')
person = Person.objects.create(name='Great singer')
membership = Membership.objects.create(
    person=person,
    group=group,
    invite_reason='Need a new drummer'
)
membership.delete()
assert group.members.count() == 0
```