### PR TITLE
Fixed SafeDeleteMixin not being abstract.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,14 @@
 CHANGELOG
 =========
 
+0.4.3
+=====
+
+** Bugfixes **
+
+- Fix SafeDeleteMixin not being abstract, it is an abstract model now.
+
+
 0.4.2
 =====
 

--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -208,6 +208,9 @@ class SafeDeleteMixin(SafeDeleteModel):
         Use :class:`SafeDeleteModel` instead.
     """
 
+    class Meta:
+        abstract = True
+
     def __init__(self, *args, **kwargs):
         warnings.warn('The SafeDeleteMixin class was renamed SafeDeleteModel',
                       DeprecationWarning)


### PR DESCRIPTION
When SafeDeleteMixin was renamed to SafeDeleteModel in #71, the deprecate SafeDeleteMixin inherited from the SafeDeleteModel. Inheriting from an abstract model in Django removes the abstract property that was applied.

You would get the following error when trying to import anything from `models.py`:
```
RuntimeError: Model class safedelete.models.SafeDeleteMixin doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```

This is on Django 1.11.3, maybe this was never noticed or it was ignored on older versions.