### PR TITLE
Make Test Cases pass on Django 2.0

### DIFF
--- a/safedelete/tests/settings.py
+++ b/safedelete/tests/settings.py
@@ -18,6 +18,17 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
 )
 
+# New style default middleware declaration for Django 1.10+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/safedelete/tests/test_prefetch_related.py
+++ b/safedelete/tests/test_prefetch_related.py
@@ -11,7 +11,8 @@ class PrefetchBrother(SafeDeleteModel):
 class PrefetchSister(SafeDeleteModel):
     sibling = models.ForeignKey(
         PrefetchBrother,
-        related_name='sisters'
+        related_name='sisters',
+        on_delete=models.CASCADE
     )
 
 

--- a/safedelete/tests/test_soft_delete_cascade.py
+++ b/safedelete/tests/test_soft_delete_cascade.py
@@ -7,12 +7,12 @@ from safedelete.tests.models import Article, Author, Category
 
 class Press(SafeDeleteModel):
     name = models.CharField(max_length=200)
-    article = models.ForeignKey(Article)
+    article = models.ForeignKey(Article, on_delete=models.CASCADE)
 
 
 class PressNormalModel(models.Model):
     name = models.CharField(max_length=200)
-    article = models.ForeignKey(Article)
+    article = models.ForeignKey(Article, on_delete=models.CASCADE)
 
 
 class CustomAbstractModel(SafeDeleteModel):
@@ -24,7 +24,7 @@ class CustomAbstractModel(SafeDeleteModel):
 class ArticleView(CustomAbstractModel):
     _safedelete_policy = SOFT_DELETE_CASCADE
 
-    article = models.ForeignKey(Article)
+    article = models.ForeignKey(Article, on_delete=models.CASCADE)
 
 
 class SimpleTest(TestCase):


### PR DESCRIPTION
Hello @makinacorpus , this is @dhilipsiva here. Apart from a minor 2.0 support, I also have another question:

My `__str__` and `__repr__` are not being utilized by SafeDeleteAdmin on the Admin Dashboard. It just shows a `-`. I tried going through the code, but I could not figure this one out. Any pointers on how to get it to work?