### PR TITLE
Possibility of undeleting related objects

### DIFF
--- a/safedelete/admin.py
+++ b/safedelete/admin.py
@@ -12,6 +12,8 @@ from django.utils.html import conditional_escape, format_html
 from django.utils.six import text_type
 from django.utils.translation import ugettext_lazy as _
 
+from .utils import related_objects
+
 
 def highlight_deleted(obj):
     """
@@ -123,6 +125,8 @@ class SafeDeleteAdmin(admin.ModelAdmin):
             objects_name = force_text(opts.verbose_name_plural)
         title = _("Are you sure?")
 
+        related_list = [list(related_objects(obj)) for obj in queryset]
+
         context = {
             'title': title,
             'objects_name': objects_name,
@@ -130,6 +134,7 @@ class SafeDeleteAdmin(admin.ModelAdmin):
             "opts": opts,
             "app_label": opts.app_label,
             'action_checkbox_name': helpers.ACTION_CHECKBOX_NAME,
+            'related_list': related_list
         }
 
         if LooseVersion(django.get_version()) < LooseVersion('1.10'):

--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -101,17 +101,25 @@ class SafeDeleteModel(models.Model):
             using = kwargs.get('using') or router.db_for_write(self.__class__, instance=self)
             post_undelete.send(sender=self.__class__, instance=self, using=using)
 
-    def undelete(self, **kwargs):
+    def undelete(self, force_policy=None, **kwargs):
         """Undelete a soft-deleted model.
 
         Args:
+            force_policy: Force a specific undelete policy. (default: {None})
             kwargs: Passed onto :func:`save`.
 
         .. note::
             Will raise a :class:`AssertionError` if the model was not soft-deleted.
         """
+        current_policy = force_policy or self._safedelete_policy
+
         assert self.deleted
         self.save(keep_deleted=False, **kwargs)
+
+        if current_policy == SOFT_DELETE_CASCADE:
+            for related in related_objects(self):
+                if is_safedelete_cls(related.__class__) and related.deleted:
+                    related.undelete()
 
     def delete(self, force_policy=None, **kwargs):
         """Overrides Django's delete behaviour based on the model's delete policy.

--- a/safedelete/queryset.py
+++ b/safedelete/queryset.py
@@ -35,7 +35,7 @@ class SafeDeleteQueryset(query.QuerySet):
         self._result_cache = None
     delete.alters_data = True
 
-    def undelete(self):
+    def undelete(self, force_policy=None):
         """Undelete all soft deleted models.
 
         .. note::
@@ -48,7 +48,7 @@ class SafeDeleteQueryset(query.QuerySet):
         assert self.query.can_filter(), "Cannot use 'limit' or 'offset' with undelete."
         # TODO: Replace this by bulk update if we can (need to call pre/post-save signal)
         for obj in self.all():
-            obj.undelete()
+            obj.undelete(force_policy=force_policy)
         self._result_cache = None
     undelete.alters_data = True
 

--- a/safedelete/templates/safedelete/undelete_selected_confirmation.html
+++ b/safedelete/templates/safedelete/undelete_selected_confirmation.html
@@ -9,6 +9,12 @@
     {% for obj in queryset %}
     <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}" />
     {% endfor %}
+
+    <p>{% blocktrans %}Related objects{% endblocktrans %}</p>
+    {% for related in related_list %}
+      <ul>{{ related | unordered_list }}</ul>
+    {% endfor %}
+
     <input type="hidden" name="action" value="undelete_selected" />
     <input type="hidden" name="post" value="yes" />
     <input type="submit" value="{% trans "Yes, I'm sure" %}" />

--- a/safedelete/tests/test_soft_delete.py
+++ b/safedelete/tests/test_soft_delete.py
@@ -8,12 +8,17 @@ from django.db import models
 
 from ..models import SafeDeleteMixin
 from ..models import SafeDeleteModel
+from ..config import SOFT_DELETE_CASCADE
 from .testcase import SafeDeleteForceTestCase
 
 
 class SoftDeleteModel(SafeDeleteModel):
     # SafeDeleteModel has the soft delete policy by default
     pass
+
+
+class SoftDeleteRelatedModel(SafeDeleteModel):
+    related = models.ForeignKey(SoftDeleteModel, on_delete=models.CASCADE)
 
 
 class SoftDeleteMixinModel(SafeDeleteMixin):
@@ -92,6 +97,21 @@ class SoftDeleteTestCase(SafeDeleteForceTestCase):
 
         SoftDeleteModel.deleted_objects.all().undelete()
         self.assertEqual(SoftDeleteModel.objects.count(), 1)
+
+    def test_undelete_with_soft_delete_policy_and_forced_soft_delete_cascade_policy(self):
+        self.assertEqual(SoftDeleteModel.objects.count(), 1)
+        SoftDeleteRelatedModel.objects.create(related=SoftDeleteModel.objects.first())
+        self.assertEqual(SoftDeleteRelatedModel.objects.count(), 1)
+
+        SoftDeleteModel.objects.all().delete()
+        self.assertEqual(SoftDeleteModel.objects.count(), 0)
+
+        SoftDeleteRelatedModel.objects.all().delete()
+        self.assertEqual(SoftDeleteRelatedModel.objects.count(), 0)
+
+        SoftDeleteModel.deleted_objects.all().undelete(force_policy=SOFT_DELETE_CASCADE)
+        self.assertEqual(SoftDeleteModel.objects.count(), 1)
+        self.assertEqual(SoftDeleteRelatedModel.objects.count(), 1)
 
     def test_validate_unique(self):
         """Check that uniqueness is also checked against deleted objects """

--- a/safedelete/tests/test_soft_delete_cascade.py
+++ b/safedelete/tests/test_soft_delete_cascade.py
@@ -89,3 +89,12 @@ class SimpleTest(TestCase):
 
         self.assertEqual(ArticleView.objects.count(), 0)
         self.assertEqual(ArticleView.all_objects.count(), 1)
+
+    def test_undelete_with_soft_delete_cascade_policy(self):
+        self.authors[2].delete(force_policy=SOFT_DELETE_CASCADE)
+        self.authors[2].undelete(force_policy=SOFT_DELETE_CASCADE)
+
+        self.assertEqual(Author.objects.count(), 3)
+        self.assertEqual(Article.objects.count(), 3)
+        self.assertEqual(Category.objects.count(), 3)
+        self.assertEqual(Press.objects.count(), 1)


### PR DESCRIPTION
Added SOFT_DELETE_CASCADE handling to undelete method of the SafeDeleteModel and SafeDeleteQuerySet. Created tests for modified methods. Modifed undelete_selected_confirmation.html with a list of related objects for undeletion.