### PR TITLE
Remove redundant line in models.py

### DIFF
--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -187,8 +187,6 @@ class SafeDeleteModel(models.Model):
             if len(unique_check) != len(lookup_kwargs):
                 continue
 
-            qs = model_class.all_objects.filter(**lookup_kwargs)
-
             # This is the changed line
             if hasattr(model_class, 'all_objects'):
                 qs = model_class.all_objects.filter(**lookup_kwargs)


### PR DESCRIPTION
The line is 

```python
qs = model_class.all_objects.filter(**lookup_kwargs)
```

It was present just before the check for `all_objects`:

```python
if hasattr(model_class, 'all_objects'):
```

So this check was useless. But instead of removing the check, I guess the intention was to have it and the duplicated line is a rest of a previous refactoring

Fixes #106 