### PR TITLE
Pyflakes v2+ does not support python 3.3 anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
  - pip install 'coverage>=3,<4'
 
  - pip install pep8
- - pip install pyflakes
+ - pip install "pyflakes<2"
 
 before_script:
     - "pep8 --ignore=E501 safedelete"


### PR DESCRIPTION
See https://github.com/PyCQA/pyflakes/blob/master/NEWS.txt

So I pinned the travis.ci file to let jobs pass on python 3.3....

Another solution would be to change the versions matrix but it's not my decision :D