### PR TITLE
Fix delete deleted on cascade soft delete

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@ CHANGELOG
 0.5.2 (unreleased)
 ==================
 
-
+- Fix executing soft delete on already soft-deleted items during cascade soft delete
 
 0.5.1 (2018-07-02)
 ==================

--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -163,7 +163,7 @@ class SafeDeleteModel(models.Model):
         elif current_policy == SOFT_DELETE_CASCADE:
             # Soft-delete on related objects before
             for related in related_objects(self):
-                if is_safedelete_cls(related.__class__):
+                if is_safedelete_cls(related.__class__) and not related.deleted:
                     related.delete(force_policy=SOFT_DELETE, **kwargs)
             # soft-delete the object
             self.delete(force_policy=SOFT_DELETE, **kwargs)

--- a/safedelete/tests/test_soft_delete_cascade.py
+++ b/safedelete/tests/test_soft_delete_cascade.py
@@ -1,6 +1,8 @@
+from unittest.mock import patch
+
 from django.db import models
 from django.test import TestCase
-from safedelete import SOFT_DELETE_CASCADE
+from safedelete import SOFT_DELETE_CASCADE, SOFT_DELETE
 from safedelete.models import SafeDeleteModel
 from safedelete.tests.models import Article, Author, Category
 
@@ -89,6 +91,14 @@ class SimpleTest(TestCase):
 
         self.assertEqual(ArticleView.objects.count(), 0)
         self.assertEqual(ArticleView.all_objects.count(), 1)
+
+    def test_soft_delete_cascade_deleted(self):
+        self.articles[0].delete(force_policy=SOFT_DELETE)
+        self.assertEqual(Article.objects.filter(author=self.authors[1]).count(), 1)
+
+        with patch('safedelete.tests.models.Article.delete') as delete_article_mock:
+            self.authors[1].delete(force_policy=SOFT_DELETE_CASCADE)
+            delete_article_mock.assert_called_once()
 
     def test_undelete_with_soft_delete_cascade_policy(self):
         self.authors[2].delete(force_policy=SOFT_DELETE_CASCADE)

--- a/safedelete/tests/test_soft_delete_cascade.py
+++ b/safedelete/tests/test_soft_delete_cascade.py
@@ -1,10 +1,14 @@
-from unittest.mock import patch
-
 from django.db import models
 from django.test import TestCase
 from safedelete import SOFT_DELETE_CASCADE, SOFT_DELETE
 from safedelete.models import SafeDeleteModel
 from safedelete.tests.models import Article, Author, Category
+
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch  # for python 2 supporting
 
 
 class Press(SafeDeleteModel):

--- a/safedelete/tests/test_soft_delete_cascade.py
+++ b/safedelete/tests/test_soft_delete_cascade.py
@@ -94,11 +94,13 @@ class SimpleTest(TestCase):
 
     def test_soft_delete_cascade_deleted(self):
         self.articles[0].delete(force_policy=SOFT_DELETE)
-        self.assertEqual(Article.objects.filter(author=self.authors[1]).count(), 1)
+        self.assertEqual(self.authors[1].article_set.count(), 1)
 
         with patch('safedelete.tests.models.Article.delete') as delete_article_mock:
             self.authors[1].delete(force_policy=SOFT_DELETE_CASCADE)
-            delete_article_mock.assert_called_once()
+
+            # delete_article_mock.assert_called_once doesn't work on py35
+            self.assertEqual(delete_article_mock.call_count, 1)
 
     def test_undelete_with_soft_delete_cascade_policy(self):
         self.authors[2].delete(force_policy=SOFT_DELETE_CASCADE)


### PR DESCRIPTION
Soft delete cascade should not mark as deleted already marked objects.