### PR TITLE
Issue 117: Avoiding recursive call for delete function.

### DIFF
--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -122,6 +122,9 @@ class SafeDeleteModel(models.Model):
                     related.undelete()
 
     def delete(self, force_policy=None, **kwargs):
+        self._delete(force_policy, **kwargs)
+
+    def _delete(self, force_policy=None, **kwargs):
         """Overrides Django's delete behaviour based on the model's delete policy.
 
         Args:
@@ -156,9 +159,9 @@ class SafeDeleteModel(models.Model):
             # Hard-delete the object only if nothing would be deleted with it
 
             if not can_hard_delete(self):
-                self.delete(force_policy=SOFT_DELETE, **kwargs)
+                self._delete(force_policy=SOFT_DELETE, **kwargs)
             else:
-                self.delete(force_policy=HARD_DELETE, **kwargs)
+                self._delete(force_policy=HARD_DELETE, **kwargs)
 
         elif current_policy == SOFT_DELETE_CASCADE:
             # Soft-delete on related objects before
@@ -166,7 +169,7 @@ class SafeDeleteModel(models.Model):
                 if is_safedelete_cls(related.__class__) and not related.deleted:
                     related.delete(force_policy=SOFT_DELETE, **kwargs)
             # soft-delete the object
-            self.delete(force_policy=SOFT_DELETE, **kwargs)
+            self._delete(force_policy=SOFT_DELETE, **kwargs)
 
     @classmethod
     def has_unique_fields(cls):

--- a/safedelete/tests/test_single_delete_call_on_inheritance.py
+++ b/safedelete/tests/test_single_delete_call_on_inheritance.py
@@ -1,0 +1,49 @@
+from ..config import (HARD_DELETE, SOFT_DELETE, SOFT_DELETE_CASCADE, HARD_DELETE_NOCASCADE, NO_DELETE)
+from ..models import SafeDeleteModel
+from django.test import TestCase
+
+
+class TestDeleteModel(SafeDeleteModel):
+    def __init__(self, *args, **kwargs):
+        # Initialize a counter to count the number of times delete method is called.
+        self.delete_call_counter = 0
+        super().__init__(*args, **kwargs)
+
+    def delete(self, force_policy=None, **kwargs):
+        super().delete(force_policy, **kwargs)
+        # Add counter on every delete method call
+        self.delete_call_counter += 1
+
+
+class TestSingleDeleteCallOnInheritance(TestCase):
+    '''Call delete for every policy and test if `delete_call_counter == 1`'''
+
+    def test_single_delete_call_for_no_delete(self):
+        instance = TestDeleteModel.objects.create()
+        instance.delete(force_policy=NO_DELETE)
+        # test NO_DELETE
+        self.assertEqual(instance.delete_call_counter, 1)
+
+    def test_single_delete_call_for_hard_delete(self):
+        instance = TestDeleteModel.objects.create()
+        instance.delete(force_policy=SOFT_DELETE)
+        # test SOFT_DELETE
+        self.assertEqual(instance.delete_call_counter, 1)
+
+    def test_single_delete_call_for_soft_delete(self):
+        instance = TestDeleteModel.objects.create()
+        instance.delete(force_policy=SOFT_DELETE_CASCADE)
+        # test SOFT_DELETE_CASCADE
+        self.assertEqual(instance.delete_call_counter, 1)
+
+    def test_single_delete_call_for_soft_delete_cascade(self):
+        instance = TestDeleteModel.objects.create()
+        instance.delete(force_policy=HARD_DELETE)
+        # test HARD_DELETE
+        self.assertEqual(instance.delete_call_counter, 1)
+
+    def test_single_delete_call_for_hard_delete_nocascade(self):
+        instance = TestDeleteModel.objects.create()
+        instance.delete(force_policy=HARD_DELETE_NOCASCADE)
+        # test HARD_DELETE_NOCASCADE
+        self.assertEqual(instance.delete_call_counter, 1)


### PR DESCRIPTION
As recommended in issue 117, created  separate function _delete and all the recursive calls are made to _delete. Thus delete method is called only once throughout.

Added a test file that check if the delete method is called once for all the safedelete policies. 