### PR TITLE
SafeDeleteModel.delete() call self.save() instead of super().save()

### DIFF
--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -142,7 +142,7 @@ class SafeDeleteModel(models.Model):
             using = kwargs.get('using') or router.db_for_write(self.__class__, instance=self)
             # send pre_softdelete signal
             pre_softdelete.send(sender=self.__class__, instance=self, using=using)
-            super(SafeDeleteModel, self).save(**kwargs)
+            self.save(keep_deleted=True, **kwargs)
             # send softdelete signal
             post_softdelete.send(sender=self.__class__, instance=self, using=using)
 


### PR DESCRIPTION
undelete() calling self.save() and delete() calling super().save() causes objects be deleted and NOT be able to undeleted in certain situations. Example: when self.save() has custom logic, validation etc.

Issue: https://github.com/makinacorpus/django-safedelete/issues/139