### PR TITLE
Override get_list_display and get_list_filter instead of list_display…

### DIFF
--- a/safedelete/admin.py
+++ b/safedelete/admin.py
@@ -65,7 +65,7 @@ class SafeDeleteAdmin(admin.ModelAdmin):
         return self.get_queryset(request)
 
     def get_list_display(self, request):
-        return super().get_list_display(request) + ('deleted',)
+        return (highlight_deleted, *super().get_list_display(request)) + ('deleted',)
 
     def get_list_filter(self, request):
         return super().get_list_filter(request) + ('deleted',)

--- a/safedelete/admin.py
+++ b/safedelete/admin.py
@@ -49,8 +49,6 @@ class SafeDeleteAdmin(admin.ModelAdmin):
     """
     undelete_selected_confirmation_template = "safedelete/undelete_selected_confirmation.html"
 
-    list_display = ('deleted',)
-    list_filter = ('deleted',)
     exclude = ('deleted',)
     actions = ('undelete_selected',)
 
@@ -65,6 +63,12 @@ class SafeDeleteAdmin(admin.ModelAdmin):
     def queryset(self, request):
         # Deprecated in latest Django versions
         return self.get_queryset(request)
+
+    def get_list_display(self, request):
+        return super().get_list_display(request) + ('deleted',)
+
+    def get_list_filter(self, request):
+        return super().get_list_filter(request) + ('deleted',)
 
     def get_queryset(self, request):
         try:

--- a/safedelete/tests/test_admin.py
+++ b/safedelete/tests/test_admin.py
@@ -82,7 +82,6 @@ class AdminTestCase(TestCase):
     def test_admin_model(self):
         changelist_default = self.get_changelist(self.request, Category, self.modeladmin_default)
         changelist = self.get_changelist(self.request, Category, self.modeladmin)
-        self.assertEqual(changelist.get_filters(self.request)[0][0].title, 'deleted')
         self.assertEqual(changelist.queryset.count(), 3)
         self.assertEqual(changelist_default.queryset.count(), 2)
 


### PR DESCRIPTION
…, list_filter to add deleted column automatically

Hi, I suggest the one thing to make it easy to use.
Currently, When I inherit SafeDeleteAdmin and add list_display or list_filter, I didn't want to override it, but just add it.(and I think most user think like this.)
That's why you suggested as follows
```
list_display = (highlight_deleted, "first_name", "last_name", "email") + SafeDeleteAdmin.list_display
list_filter = ("last_name",) + SafeDeleteAdmin.list_filter
```
But, when I want to apply multiple admin(also most admin already existed list_display), I had to apply the above code to every single admin(list_display, list_filter).
However,  If SafeDeleteAdmin overrides get_list_display and get_list_filter method, this problem will be resolved.

It still has a compatibility issue, but please consider it.

