### PR TITLE
Set related fields when soft deleted

### DIFF
--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -166,7 +166,7 @@ class SafeDeleteModel(models.Model):
             for related in related_objects(self):
                 if is_safedelete_cls(related.__class__) and not related.deleted:
                     related.delete(force_policy=SOFT_DELETE, **kwargs)
-            
+
             collector = NestedObjects(using=router.db_for_write(self))
             collector.collect([self])
             # update fields (SET, SET_DEFAULT or SET_NULL)
@@ -178,7 +178,7 @@ class SafeDeleteModel(models.Model):
                         {field.name: value},
                         collector.using,
                     )
-            
+
             # soft-delete the object
             self.delete(force_policy=SOFT_DELETE, **kwargs)
 

--- a/safedelete/tests/test_soft_delete_cascade.py
+++ b/safedelete/tests/test_soft_delete_cascade.py
@@ -1,4 +1,3 @@
-from django.db.models.fields.related import ForeignKey
 from django.db import models
 from django.test import TestCase
 from safedelete import SOFT_DELETE_CASCADE, SOFT_DELETE

--- a/safedelete/tests/test_soft_delete_cascade.py
+++ b/safedelete/tests/test_soft_delete_cascade.py
@@ -19,7 +19,7 @@ class Press(SafeDeleteModel):
 
 class PressNormalModel(models.Model):
     name = models.CharField(max_length=200)
-    article = models.ForeignKey(Article, on_delete=models.CASCADE)
+    article = models.ForeignKey(Article, on_delete=models.CASCADE, null=True)
 
 
 class CustomAbstractModel(SafeDeleteModel):
@@ -89,22 +89,22 @@ class SimpleTest(TestCase):
 
     def test_soft_delete_cascade_with_set_null(self):
         PressNormalModel.article.field.null = True
-        PressNormalModel.article.field.remote_field.on_delete=models.SET_NULL
+        PressNormalModel.article.field.remote_field.on_delete = models.SET_NULL
         PressNormalModel.objects.create(name='press 0', article=self.articles[2])
         self.authors[2].delete(force_policy=SOFT_DELETE_CASCADE)
 
         self.assertEqual(PressNormalModel.objects.first().article, None)
 
     def test_soft_delete_cascade_with_set_default(self):
-        PressNormalModel.article.field.default=self.articles[1]
-        PressNormalModel.article.field.remote_field.on_delete=models.SET_DEFAULT
+        PressNormalModel.article.field.default = self.articles[1]
+        PressNormalModel.article.field.remote_field.on_delete = models.SET_DEFAULT
         PressNormalModel.objects.create(name='press 0', article=self.articles[2])
         self.authors[2].delete(force_policy=SOFT_DELETE_CASCADE)
 
         self.assertEqual(PressNormalModel.objects.first().article, self.articles[1])
 
     def test_soft_delete_cascade_with_set(self):
-        PressNormalModel.article.field.remote_field.on_delete=models.SET(self.articles[0])
+        PressNormalModel.article.field.remote_field.on_delete = models.SET(self.articles[0])
         PressNormalModel.objects.create(name='press 0', article=self.articles[2])
         self.authors[2].delete(force_policy=SOFT_DELETE_CASCADE)
 


### PR DESCRIPTION
Set related fields per `on_delete` value when calling delete with `SOFT_DELETE_CASCADE` policy
#141