### PR TITLE
Add visibility filter for union operations

### DIFF
--- a/safedelete/queryset.py
+++ b/safedelete/queryset.py
@@ -145,6 +145,15 @@ class SafeDeleteQueryset(query.QuerySet):
 
         return attr
 
+    def _combinator_query(self, combinator, *other_qs, **kwargs):
+        # Filter visibility for operations like union, difference and intersection
+        self._filter_visibility()
+        for qs in other_qs:
+            qs._filter_visibility()
+        return super(SafeDeleteQueryset, self)._combinator_query(
+            combinator, *other_qs, **kwargs
+        )
+
     def _clone(self, klass=None, **kwargs):
         """Called by django when cloning a QuerySet."""
         if LooseVersion(django.get_version()) < LooseVersion('1.9'):

--- a/safedelete/tests/test_queryset.py
+++ b/safedelete/tests/test_queryset.py
@@ -209,3 +209,75 @@ class QuerySetTestCase(SafeDeleteTestCase):
             instance.id,
             QuerySetModel.objects.filter(id=instance.id).values_list('pk', flat=True)[0]
         )
+
+    def test_union(self):
+        # Test whether the soft deleted model can be found by union."""
+        queryset = QuerySetModel.objects.all()
+        self.assertEqual(
+            queryset.union(queryset).count(),
+            0
+        )
+
+        queryset = QuerySetModel.all_objects.all()
+        self.assertEqual(
+            queryset.union(queryset, all=False).count(),
+            1
+        )
+        self.assertEqual(
+            queryset.union(queryset, all=True).count(),
+            2
+        )
+
+    def test_difference(self):
+        # Test whether the soft deleted model can be found by difference."""
+        instance = QuerySetModel.objects.create(
+            other=self.other
+        )
+        queryset = QuerySetModel.objects.filter(id=instance.id)
+        self.assertEqual(
+            queryset.difference(
+                QuerySetModel.objects.all()
+            ).count(),
+            0
+        )
+
+        queryset = QuerySetModel.all_objects.all()
+        self.assertEqual(
+            queryset.difference(
+                QuerySetModel.objects.all()
+            ).count(),
+            1
+        )
+        self.assertEqual(
+            queryset.difference(
+                QuerySetModel.all_objects.all()
+            ).count(),
+            0
+        )
+
+    def test_intersection(self):
+        # Test whether the soft deleted model can be found by intersection."""
+        instance = QuerySetModel.objects.create(
+            other=self.other
+        )
+        queryset = QuerySetModel.objects.filter(id=instance.id)
+        self.assertEqual(
+            queryset.intersection(
+                QuerySetModel.objects.all()
+            ).count(),
+            1
+        )
+
+        queryset = QuerySetModel.all_objects.all()
+        self.assertEqual(
+            queryset.intersection(
+                QuerySetModel.objects.all()
+            ).count(),
+            1
+        )
+        self.assertEqual(
+            queryset.intersection(
+                QuerySetModel.all_objects.all()
+            ).count(),
+            2
+        )


### PR DESCRIPTION
Add visibility filter for queryset operations such as `union`, `difference` and `intersection`
#97 