### PR TITLE
Fix attribute error when union queryset of safe delete model with others

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -57,4 +57,4 @@ jobs:
     - name: Coverage
       if: ${{ success() }}
       run: |
-        coveralls
+        coveralls --service=github

--- a/safedelete/queryset.py
+++ b/safedelete/queryset.py
@@ -153,7 +153,8 @@ class SafeDeleteQueryset(query.QuerySet):
         # Filter visibility for operations like union, difference and intersection
         self._filter_visibility()
         for qs in other_qs:
-            qs._filter_visibility()
+            if hasattr(qs, "_filter_visibility"):
+                qs._filter_visibility()
         return super(SafeDeleteQueryset, self)._combinator_query(
             combinator, *other_qs, **kwargs
         )

--- a/safedelete/tests/test_queryset.py
+++ b/safedelete/tests/test_queryset.py
@@ -210,6 +210,28 @@ class QuerySetTestCase(SafeDeleteTestCase):
             QuerySetModel.objects.filter(id=instance.id).values_list('pk', flat=True)[0]
         )
 
+    def test_union_with_different_models(self):
+        # Test the safe deleted model can union with other models."""
+        queryset = QuerySetModel.objects.values_list("pk")
+        other_queryset = OtherModel.objects.values_list("pk")
+        self.assertEqual(
+            queryset.union(other_queryset).count(),
+            1
+        )
+        self.assertEqual(
+            other_queryset.union(queryset).count(),
+            1
+        )
+        queryset = QuerySetModel.all_objects.values_list("pk")
+        self.assertEqual(
+            queryset.union(other_queryset, all=True).count(),
+            2
+        )
+        self.assertEqual(
+            other_queryset.union(queryset, all=True).count(),
+            2
+        )
+
     def test_union(self):
         # Test whether the soft deleted model can be found by union."""
         queryset = QuerySetModel.objects.all()


### PR DESCRIPTION
- Bug fix: A safedelete model queryset union with another regular model queryset will raise an attribute error:
`AttributeError: 'QuerySet' object has no attribute '_filter_visibility'`

- Also fixed 422 Client Error when submitting coverage.