### PR TITLE
SET related objects after deleting

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,6 @@ jobs:
             python_version: '3.5'
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
     steps:
     - uses: actions/checkout@v2
@@ -57,4 +56,4 @@ jobs:
     - name: Coverage
       if: ${{ success() }}
       run: |
-        coveralls
+        coveralls --service=github

--- a/safedelete/__init__.py
+++ b/safedelete/__init__.py
@@ -16,4 +16,3 @@ __all__ = [
 ]
 
 __version__ = "1.0.1dev"
-default_app_config = 'safedelete.apps.SafeDeleteConfig'

--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -167,6 +167,9 @@ class SafeDeleteModel(models.Model):
                 if is_safedelete_cls(related.__class__) and not related.deleted:
                     related.delete(force_policy=SOFT_DELETE, **kwargs)
 
+            # soft-delete the object
+            self.delete(force_policy=SOFT_DELETE, **kwargs)
+
             collector = NestedObjects(using=router.db_for_write(self))
             collector.collect([self])
             # update fields (SET, SET_DEFAULT or SET_NULL)
@@ -178,9 +181,6 @@ class SafeDeleteModel(models.Model):
                         {field.name: value},
                         collector.using,
                     )
-
-            # soft-delete the object
-            self.delete(force_policy=SOFT_DELETE, **kwargs)
 
     @classmethod
     def has_unique_fields(cls):

--- a/safedelete/tests/test_prefetch_related.py
+++ b/safedelete/tests/test_prefetch_related.py
@@ -43,7 +43,8 @@ class PrefetchTestCase(SafeDeleteTestCase):
                     repr(s) for s in PrefetchBrother.objects.get(
                         pk=brother.pk
                     ).sisters.all().order_by('pk')
-                ]
+                ],
+                repr
             )
 
     def test_prefetch_related_is_evaluated_once(self):


### PR DESCRIPTION
- Related objects should not be updated before `pre_softdelete` or `pre_delete` signal was sent.
- Fixed deprecated warnings
- Removed overall repo token https://github.com/TheKevJames/coveralls-python/issues/206