### PR TITLE
Add Django 3.2 in tox configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,7 @@ Current branch (1.0.x) is tested with :
 *  Django 2.2 using python 3.5 to 3.9.
 *  Django 3.0 using python 3.6 to 3.9.
 *  Django 3.1 using python 3.6 to 3.9.
+*  Django 3.2 using python 3.6 to 3.9.
 
 
 Installation

--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -14,6 +14,7 @@ Visibility
 A custom manager is used to determine which objects should be included in the querysets.
 
 .. autoclass:: SafeDeleteManager
+    :noindex:
 
 If you want to change which objects are "masked", you can set the ``_safedelete_visibility``
 attribute of the manager to one of the following:

--- a/safedelete/tests/settings.py
+++ b/safedelete/tests/settings.py
@@ -53,3 +53,6 @@ TEMPLATES = [
         },
     },
 ]
+
+# This is for Django 3.2, harmless for previous versions.
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 skipsdist = True
 envlist =
     {py35}-django-{22}
-    {py36}-django-{22,30,31}
-    {py37}-django-{22,30,31}
-    {py38}-django-{22,30,31}
-    {py39}-django-{22,30,31}
+    {py36}-django-{22,30,31,32}
+    {py37}-django-{22,30,31,32}
+    {py38}-django-{22,30,31,32}
+    {py39}-django-{22,30,31,32}
     {py39}-flake8
 
 [testenv]
@@ -19,6 +19,7 @@ deps =
     django-22: Django>=2.2,<2.3
     django-30: Django>=3.0,<3.1
     django-31: Django>=3.1,<3.2
+    django-32: Django>=3.2,<3.3
 commands =
     flake8: flake8 safedelete --ignore=E501
     django: coverage run --parallel-mode {toxinidir}/runtests.py {posargs}
@@ -30,6 +31,6 @@ changedir = docs
 deps =
     sphinx
     sphinx_rtd_theme
-    Django>=2.2,<3.0
+    Django>=2.2,<3.3
 commands =
     sphinx-build -W -b html -d build/doctrees . build/html


### PR DESCRIPTION
This simply adds Django 3.2 to the tox test configuration and a single new setting in the test project's Django settings file to prevent Django 3.2 warnings about BigAutoFields.

Looks like all the tests pass!

Also updates the docs to show that Django 3.2 is supported (at least from a test-perspective).