### PR TITLE
 Refactoring of policies actions into overwritable methods

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ CHANGELOG
 - SET related objects after deleting #156
 - Avoiding recursive call for delete function. #121
 - Add SAFE_DELETE_FIELD_NAME setting #164
+- Add functions to customize the policies delete behavior #167
 
 1.0.0 (2021-02-15)
 ==================

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -47,3 +47,34 @@ The different policies are:
 
     This policy will:
         - Keep the objects from being masked or deleted from your database. The only way of removing objects will be by using raw SQL.
+
+
+Policies Delete Logic Customization
+--------
+
+Each of the policies has an overwritable function in case you need to customize a particular policy delete logic. The function per policy are as follows:
+
+.. list-table::
+    :widths: 15 10
+    :header-rows: 1
+    :align: center
+
+    * - Policy
+      - Overwritable Function
+    * - SOFT_DELETE
+      - soft_delete_policy_action
+    * - HARD_DELETE
+      - hard_delete_policy_action
+    * - HARD_DELETE_NOCASCADE
+      - hard_delete_cascade_policy_action
+    * - SOFT_DELETE_CASCADE
+      - soft_delete_cascade_policy_action    
+
+    Example:
+To add custom logic before or after the execution of the original delete logic of a model with the policy SOFT_DELETE you can overwrite the ``soft_delete_policy_action`` function as such:
+
+.. code-block:: python
+    def soft_delete_policy_action(self, **kwargs):
+        # Insert here custom pre delete logic
+        super().soft_delete_policy_action(**kwargs)
+        # Insert here custom post delete logic

--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -140,21 +140,21 @@ class SafeDeleteModel(models.Model):
 
         elif current_policy == SOFT_DELETE:
 
-            self._soft_delete_policy_action(**kwargs)
+            self.soft_delete_policy_action(**kwargs)
 
         elif current_policy == HARD_DELETE:
 
-           self._hard_delete_policy_action(**kwargs)
+           self.hard_delete_policy_action(**kwargs)
 
         elif current_policy == HARD_DELETE_NOCASCADE:
 
-            self._hard_delete_cascade_policy_action(**kwargs)
+            self.hard_delete_cascade_policy_action(**kwargs)
 
         elif current_policy == SOFT_DELETE_CASCADE:
 
-            self._soft_delete_cascade_policy_action(**kwargs)
+            self.soft_delete_cascade_policy_action(**kwargs)
 
-    def _soft_delete_policy_action(self, **kwargs):
+    def soft_delete_policy_action(self, **kwargs):
          # Only soft-delete the object, marking it as deleted.
         setattr(self, FIELD_NAME, timezone.now())
         using = kwargs.get('using') or router.db_for_write(self.__class__, instance=self)
@@ -164,18 +164,18 @@ class SafeDeleteModel(models.Model):
         # send softdelete signal
         post_softdelete.send(sender=self.__class__, instance=self, using=using)
 
-    def _hard_delete_policy_action(self, **kwargs):
+    def hard_delete_policy_action(self, **kwargs):
         # Normally hard-delete the object.
         super(SafeDeleteModel, self).delete()
 
-    def _hard_delete_cascade_policy_action(self, **kwargs):
+    def hard_delete_cascade_policy_action(self, **kwargs):
         # Hard-delete the object only if nothing would be deleted with it
         if not can_hard_delete(self):
             self._delete(force_policy=SOFT_DELETE, **kwargs)
         else:
             self._delete(force_policy=HARD_DELETE, **kwargs)
 
-    def _soft_delete_cascade_policy_action(self, **kwargs):
+    def soft_delete_cascade_policy_action(self, **kwargs):
         # Soft-delete on related objects before
         for related in related_objects(self):
             if is_safedelete_cls(related.__class__) and not getattr(related, FIELD_NAME):

--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -140,49 +140,61 @@ class SafeDeleteModel(models.Model):
 
         elif current_policy == SOFT_DELETE:
 
-            # Only soft-delete the object, marking it as deleted.
-            setattr(self, FIELD_NAME, timezone.now())
-            using = kwargs.get('using') or router.db_for_write(self.__class__, instance=self)
-            # send pre_softdelete signal
-            pre_softdelete.send(sender=self.__class__, instance=self, using=using)
-            self.save(keep_deleted=True, **kwargs)
-            # send softdelete signal
-            post_softdelete.send(sender=self.__class__, instance=self, using=using)
+            self._soft_delete_policy_action(**kwargs)
 
         elif current_policy == HARD_DELETE:
 
-            # Normally hard-delete the object.
-            super(SafeDeleteModel, self).delete()
+           self._hard_delete_policy_action(**kwargs)
 
         elif current_policy == HARD_DELETE_NOCASCADE:
 
-            # Hard-delete the object only if nothing would be deleted with it
-
-            if not can_hard_delete(self):
-                self._delete(force_policy=SOFT_DELETE, **kwargs)
-            else:
-                self._delete(force_policy=HARD_DELETE, **kwargs)
+            self._hard_delete_cascade_policy_action(**kwargs)
 
         elif current_policy == SOFT_DELETE_CASCADE:
-            # Soft-delete on related objects before
-            for related in related_objects(self):
-                if is_safedelete_cls(related.__class__) and not getattr(related, FIELD_NAME):
-                    related.delete(force_policy=SOFT_DELETE, **kwargs)
 
-            # soft-delete the object
+            self._soft_delete_cascade_policy_action(**kwargs)
+
+    def _soft_delete_policy_action(self, **kwargs):
+         # Only soft-delete the object, marking it as deleted.
+        setattr(self, FIELD_NAME, timezone.now())
+        using = kwargs.get('using') or router.db_for_write(self.__class__, instance=self)
+        # send pre_softdelete signal
+        pre_softdelete.send(sender=self.__class__, instance=self, using=using)
+        self.save(keep_deleted=True, **kwargs)
+        # send softdelete signal
+        post_softdelete.send(sender=self.__class__, instance=self, using=using)
+
+    def _hard_delete_policy_action(self, **kwargs):
+        # Normally hard-delete the object.
+        super(SafeDeleteModel, self).delete()
+
+    def _hard_delete_cascade_policy_action(self, **kwargs):
+        # Hard-delete the object only if nothing would be deleted with it
+        if not can_hard_delete(self):
             self._delete(force_policy=SOFT_DELETE, **kwargs)
+        else:
+            self._delete(force_policy=HARD_DELETE, **kwargs)
 
-            collector = NestedObjects(using=router.db_for_write(self))
-            collector.collect([self])
-            # update fields (SET, SET_DEFAULT or SET_NULL)
-            for model, instances_for_fieldvalues in collector.field_updates.items():
-                for (field, value), instances in instances_for_fieldvalues.items():
-                    query = models.sql.UpdateQuery(model)
-                    query.update_batch(
-                        [obj.pk for obj in instances],
-                        {field.name: value},
-                        collector.using,
-                    )
+    def _soft_delete_cascade_policy_action(self, **kwargs):
+        # Soft-delete on related objects before
+        for related in related_objects(self):
+            if is_safedelete_cls(related.__class__) and not getattr(related, FIELD_NAME):
+                related.delete(force_policy=SOFT_DELETE, **kwargs)
+
+        # soft-delete the object
+        self._delete(force_policy=SOFT_DELETE, **kwargs)
+
+        collector = NestedObjects(using=router.db_for_write(self))
+        collector.collect([self])
+        # update fields (SET, SET_DEFAULT or SET_NULL)
+        for model, instances_for_fieldvalues in collector.field_updates.items():
+            for (field, value), instances in instances_for_fieldvalues.items():
+                query = models.sql.UpdateQuery(model)
+                query.update_batch(
+                    [obj.pk for obj in instances],
+                    {field.name: value},
+                    collector.using,
+                )
 
     @classmethod
     def has_unique_fields(cls):


### PR DESCRIPTION
Hello, I created this PR refactoring the policies delete logic into their own methods. Intended to offer entry points for developers to inject their own custom logic before or after a particular policy logic execution through the use of super function.

Use case e.g: If the developer wants to check a condition for the object instance only before or after the execution of the `SOFT_DELETE` policy they could overwrite the following method:

```
class MyModel(SafeDeleteModel):

    def _soft_delete_policy_action(self, **kwargs):
        # Check condition or write custom logic here
        super(MyModel, self)._soft_delete_policy_action(**kwargs)
        # Check condition or write custom logic here
```

Let me know if it's an acceptable change and I'll write the docs as well.