### PR TITLE
Add new safedelete admin filter

### DIFF
--- a/safedelete/admin.py
+++ b/safedelete/admin.py
@@ -41,7 +41,7 @@ class SafeDeleteAdminFilter(admin.SimpleListFilter):
     """
         Filters objects by whether or not they have been deleted
     """
-    title = "Deleted"
+    title = _("Deleted")
     parameter_name = FIELD_NAME
 
     def lookups(self, request, model_admin):

--- a/safedelete/admin.py
+++ b/safedelete/admin.py
@@ -37,7 +37,7 @@ def highlight_deleted(obj):
 highlight_deleted.short_description = _("Name")
 
 
-class SoftDeleteAdminFilter(admin.SimpleListFilter):
+class SafeDeleteAdminFilter(admin.SimpleListFilter):
     """
         Filters objects by whether or not they have been deleted
     """
@@ -66,10 +66,10 @@ class SafeDeleteAdmin(admin.ModelAdmin):
 
     :Example:
 
-        >>> from safedelete.admin import SafeDeleteAdmin, SoftDeleteAdminFilter, highlight_deleted
+        >>> from safedelete.admin import SafeDeleteAdmin, SafeDeleteAdminFilter, highlight_deleted
         >>> class ContactAdmin(SafeDeleteAdmin):
         ...    list_display = (highlight_deleted, "first_name", "last_name", "email") + SafeDeleteAdmin.list_display
-        ...    list_filter = ("last_name", SoftDeleteAdminFilter,) + SafeDeleteAdmin.list_filter
+        ...    list_filter = ("last_name", SafeDeleteAdminFilter,) + SafeDeleteAdmin.list_filter
     """
     undelete_selected_confirmation_template = "safedelete/undelete_selected_confirmation.html"
 

--- a/safedelete/admin.py
+++ b/safedelete/admin.py
@@ -41,7 +41,7 @@ class SafeDeleteAdminFilter(admin.SimpleListFilter):
     """
         Filters objects by whether or not they have been deleted
     """
-    title = FIELD_NAME
+    title = "Deleted"
     parameter_name = FIELD_NAME
 
     def lookups(self, request, model_admin):

--- a/safedelete/admin.py
+++ b/safedelete/admin.py
@@ -52,12 +52,12 @@ class SafeDeleteAdminFilter(admin.SimpleListFilter):
         return lookups
 
     def queryset(self, request, queryset):
-        parameter = True
+        parameter_is_null = True
         if self.value() == self.parameter_name:
             return queryset
         elif self.value() == self.parameter_name + "_only":
-            parameter = False
-        return queryset.filter(**{self.parameter_name + '__isnull': parameter})
+            parameter_is_null = False
+        return queryset.filter(**{self.parameter_name + '__isnull': parameter_is_null})
 
 
 class SafeDeleteAdmin(admin.ModelAdmin):

--- a/safedelete/tests/test_admin.py
+++ b/safedelete/tests/test_admin.py
@@ -94,31 +94,32 @@ class AdminTestCase(TestCase):
         self.assertContains(resp, line)
 
     def test_soft_delete_admin_filter(self):
-        # Check filter is added properly to list_filter
         self.modeladmin.list_filter += (SafeDeleteAdminFilter,)
-        changelist = self.get_changelist(self.request, Category, self.modeladmin)
-        self.assertEqual(changelist.get_filters(self.request)[0][1].title, FIELD_NAME.replace('_', ' '))
 
         # Check default filter
-        queryset = changelist.get_queryset(self.request)
-        self.assertIn(Category.all_objects.get(pk=self.categories[0].pk), queryset)
-        self.assertNotIn(Category.all_objects.get(pk=self.categories[1].pk), queryset)
+        with self.subTest():
+            changelist = self.get_changelist(self.request, Category, self.modeladmin)
+            queryset = changelist.get_queryset(self.request)
+            self.assertIn(Category.all_objects.get(pk=self.categories[0].pk), queryset)
+            self.assertNotIn(Category.all_objects.get(pk=self.categories[1].pk), queryset)
 
         # Change filter value to FIELD_NAME
-        request = self.request_factory.get('/', {FIELD_NAME: FIELD_NAME})
-        request.user = self.request.user
-        changelist = self.modeladmin.get_changelist_instance(request)
-        queryset = changelist.get_queryset(request)
-        self.assertIn(Category.all_objects.get(pk=self.categories[0].pk), queryset)
-        self.assertIn(Category.all_objects.get(pk=self.categories[1].pk), queryset)
+        with self.subTest():
+            request = self.request_factory.get('/', {FIELD_NAME: FIELD_NAME})
+            request.user = self.request.user
+            changelist = self.modeladmin.get_changelist_instance(request)
+            queryset = changelist.get_queryset(request)
+            self.assertIn(Category.all_objects.get(pk=self.categories[0].pk), queryset)
+            self.assertIn(Category.all_objects.get(pk=self.categories[1].pk), queryset)
 
         # Change filter value to FIELD_NAME + '_only'
-        request = self.request_factory.get('/', {FIELD_NAME: FIELD_NAME + '_only'})
-        request.user = self.request.user
-        changelist = self.modeladmin.get_changelist_instance(request)
-        queryset = changelist.get_queryset(request)
-        self.assertNotIn(Category.all_objects.get(pk=self.categories[0].pk), queryset)
-        self.assertIn(Category.all_objects.get(pk=self.categories[1].pk), queryset)
+        with self.subTest():
+            request = self.request_factory.get('/', {FIELD_NAME: FIELD_NAME + '_only'})
+            request.user = self.request.user
+            changelist = self.modeladmin.get_changelist_instance(request)
+            queryset = changelist.get_queryset(request)
+            self.assertNotIn(Category.all_objects.get(pk=self.categories[0].pk), queryset)
+            self.assertIn(Category.all_objects.get(pk=self.categories[1].pk), queryset)
 
     def test_admin_xss(self):
         """Test whether admin XSS is blocked."""

--- a/safedelete/tests/test_admin.py
+++ b/safedelete/tests/test_admin.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import User
 from django.db import models
 from django.test import RequestFactory, TestCase
 
-from ..admin import SafeDeleteAdmin, highlight_deleted, SoftDeleteAdminFilter
+from ..admin import SafeDeleteAdmin, highlight_deleted, SafeDeleteAdminFilter
 from ..config import FIELD_NAME
 from ..models import SafeDeleteModel
 from .models import Article, Author, Category
@@ -94,7 +94,7 @@ class AdminTestCase(TestCase):
         self.assertContains(resp, line)
 
     def test_soft_delete_admin_filter(self):
-        self.modeladmin.list_filter += (SoftDeleteAdminFilter,)
+        self.modeladmin.list_filter += (SafeDeleteAdminFilter,)
         changelist = self.get_changelist(self.request, Category, self.modeladmin)
         self.assertEqual(changelist.get_filters(self.request)[0][1].title, FIELD_NAME.replace('_', ' '))
 

--- a/safedelete/tests/test_admin.py
+++ b/safedelete/tests/test_admin.py
@@ -96,15 +96,13 @@ class AdminTestCase(TestCase):
     def test_soft_delete_admin_filter(self):
         self.modeladmin.list_filter += (SafeDeleteAdminFilter,)
 
-        # Check default filter
-        with self.subTest():
+        with self.subTest("test_filter_unfiltered"):
             changelist = self.get_changelist(self.request, Category, self.modeladmin)
             queryset = changelist.get_queryset(self.request)
             self.assertIn(Category.all_objects.get(pk=self.categories[0].pk), queryset)
             self.assertNotIn(Category.all_objects.get(pk=self.categories[1].pk), queryset)
 
-        # Change filter value to FIELD_NAME
-        with self.subTest():
+        with self.subTest("test_filter_FIELD_NAME"):
             request = self.request_factory.get('/', {FIELD_NAME: FIELD_NAME})
             request.user = self.request.user
             changelist = self.modeladmin.get_changelist_instance(request)
@@ -112,8 +110,7 @@ class AdminTestCase(TestCase):
             self.assertIn(Category.all_objects.get(pk=self.categories[0].pk), queryset)
             self.assertIn(Category.all_objects.get(pk=self.categories[1].pk), queryset)
 
-        # Change filter value to FIELD_NAME + '_only'
-        with self.subTest():
+        with self.subTest("test_filter_FIELD_NAME_only"):
             request = self.request_factory.get('/', {FIELD_NAME: FIELD_NAME + '_only'})
             request.user = self.request.user
             changelist = self.modeladmin.get_changelist_instance(request)

--- a/safedelete/tests/test_admin.py
+++ b/safedelete/tests/test_admin.py
@@ -102,7 +102,7 @@ class AdminTestCase(TestCase):
             self.assertIn(Category.all_objects.get(pk=self.categories[0].pk), queryset)
             self.assertNotIn(Category.all_objects.get(pk=self.categories[1].pk), queryset)
 
-        with self.subTest("test_filter_FIELD_NAME"):
+        with self.subTest("test_filter_equals_FIELD_NAME"):
             request = self.request_factory.get('/', {FIELD_NAME: FIELD_NAME})
             request.user = self.request.user
             changelist = self.modeladmin.get_changelist_instance(request)
@@ -110,7 +110,7 @@ class AdminTestCase(TestCase):
             self.assertIn(Category.all_objects.get(pk=self.categories[0].pk), queryset)
             self.assertIn(Category.all_objects.get(pk=self.categories[1].pk), queryset)
 
-        with self.subTest("test_filter_FIELD_NAME_only"):
+        with self.subTest("test_filter_equals_FIELD_NAME_only"):
             request = self.request_factory.get('/', {FIELD_NAME: FIELD_NAME + '_only'})
             request.user = self.request.user
             changelist = self.modeladmin.get_changelist_instance(request)


### PR DESCRIPTION
Closes #171 

Created this filter as indicated in my issue. I'm having trouble, however, figuring out how to programmatically change the filter value for testing. See the TODOs. Hoping someone can help me out.

Based on what I found [here](https://stackoverflow.com/questions/16751325/test-a-custom-filter-in-admin-py), I tried something like this:

```
filter = SoftDeleteAdminFilter(request=None, params={FIELD_NAME: FIELD_NAME}, model=Category, model_admin=self.modeladmin)
self.assertTrue(filter.queryset(None, Category.objects.filter(pk=self.categories[1].pk))[0])
```

But no luck.
