### PR TITLE
Add highlight_deleted_field

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -13,4 +13,8 @@ An undelete action is provided to undelete objects in bulk. The ``deleted`` attr
 
 You can use the ``highlight_deleted`` method to show deleted objects in red in the admin listing.
 
+You also have the option of using ``highlight_deleted_field`` which is similar to ``highlight_deleted``, but allows you to specify a field for sorting and representation. Whereas ``highlight_deleted`` uses your object's ``__str__`` function to represent the object, ``highlight_deleted_field`` uses the value from your object's specified field.
+
+To use ``highlihgt_deleted_field``, add "highlight_deleted_field" to your list filters (as a string, seen in the example below), and set `admin.field_to_highlight = "desired_field_name"` (also seen below).
+
 .. autoclass:: SafeDeleteAdmin

--- a/safedelete/admin.py
+++ b/safedelete/admin.py
@@ -48,6 +48,8 @@ class SafeDeleteAdmin(admin.ModelAdmin):
         >>> class ContactAdmin(SafeDeleteAdmin):
         ...    list_display = (highlight_deleted, "highlight_deleted_field", "first_name", "last_name", "email") + SafeDeleteAdmin.list_display
         ...    list_filter = ("last_name",) + SafeDeleteAdmin.list_filter
+        ...
+        ...    self.field_to_highlight = "id"
     """
     undelete_selected_confirmation_template = "safedelete/undelete_selected_confirmation.html"
 

--- a/safedelete/admin.py
+++ b/safedelete/admin.py
@@ -176,9 +176,10 @@ class SafeDeleteAdmin(admin.ModelAdmin):
         else:
             return format_html('<span class="deleted">{0}</span>', field_str)
 
-    # Meant to be overwritten; defaults to FIELD_NAME, because we know it must exist
+    # field_to_highlight is meant to be overwritten
+    # defaults to FIELD_NAME, because we know it must exist
     field_to_highlight = FIELD_NAME
-    highlight_deleted_field.short_description = _("Name")
+    highlight_deleted_field.short_description = _(field_to_highlight)
     highlight_deleted_field.admin_order_field = "_highlighted_field"
 
     undelete_selected.short_description = _("Undelete selected %(verbose_name_plural)s.")

--- a/safedelete/tests/test_admin.py
+++ b/safedelete/tests/test_admin.py
@@ -93,6 +93,13 @@ class AdminTestCase(TestCase):
         line = '<span class="deleted">{0}</span>'.format(self.categories[1])
         self.assertContains(resp, line)
 
+    def test_highlight_deleted_field(self):
+        self.modeladmin.field_to_highlight = "name"
+        self.modeladmin.list_display = ("highlight_deleted_field",)
+        resp = self.client.get('/admin/safedelete/category/')
+        line = '<span class="deleted">{0}</span>'.format(self.categories[1])
+        self.assertContains(resp, line)
+
     def test_admin_xss(self):
         """Test whether admin XSS is blocked."""
         Category.objects.create(name='<script>alert(42)</script>'),


### PR DESCRIPTION
Highlights deleted objects based on a field instead of the whole object; also, it's sortable

Some thoughts:
1 ) Not strictly necessary, but it might be good to run a test somehow that it's indeed sortable
2) I defaulted the field to FIELD_NAME (i.e. 'deleted'), because it's guaranteed to exist, which obviates a whole bunch of try-catch