### PR TITLE
Bug: has_unique_fields() returns false for models.UniqueConstraint

### DIFF
--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -3,6 +3,7 @@ import warnings
 import django
 from django.contrib.admin.utils import NestedObjects
 from django.db import models, router
+from django.db.models import UniqueConstraint
 from django.utils import timezone
 
 from .config import (HARD_DELETE, HARD_DELETE_NOCASCADE, NO_DELETE,
@@ -200,9 +201,13 @@ class SafeDeleteModel(models.Model):
         if cls._meta.unique_together:
             return True
 
-        if django.VERSION[0] >= 3 or (django.VERSION[0] == 2 and django.VERSION[1] >= 2):
+        if django.VERSION[0] > 3 or (django.VERSION[0] == 3 and django.VERSION[1] >= 1):
             if cls._meta.total_unique_constraints:
                 return True
+        else:  # derived from total_unique_constraints in django >= 3.1
+            for constraint in cls._meta.constraints:
+                if isinstance(constraint, UniqueConstraint) and constraint.condition is None:
+                    return True
 
         for field in cls._meta.fields:
             if field._unique:

--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -199,6 +199,11 @@ class SafeDeleteModel(models.Model):
         if cls._meta.unique_together:
             return True
 
+        """
+        if cls._meta.total_unique_constraints:
+            return True
+        """
+
         for field in cls._meta.fields:
             if field._unique:
                 return True

--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -199,10 +199,8 @@ class SafeDeleteModel(models.Model):
         if cls._meta.unique_together:
             return True
 
-        """
         if cls._meta.total_unique_constraints:
             return True
-        """
 
         for field in cls._meta.fields:
             if field._unique:

--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -1,5 +1,6 @@
 import warnings
 
+import django
 from django.contrib.admin.utils import NestedObjects
 from django.db import models, router
 from django.utils import timezone
@@ -199,8 +200,9 @@ class SafeDeleteModel(models.Model):
         if cls._meta.unique_together:
             return True
 
-        if cls._meta.total_unique_constraints:
-            return True
+        if django.VERSION[0] >= 3 or (django.VERSION[0] == 2 and django.VERSION[1] >= 2):
+            if cls._meta.total_unique_constraints:
+                return True
 
         for field in cls._meta.fields:
             if field._unique:

--- a/safedelete/tests/test_soft_delete.py
+++ b/safedelete/tests/test_soft_delete.py
@@ -168,16 +168,15 @@ class SoftDeleteTestCase(SafeDeleteForceTestCase):
         self.assertEqual(created, False)
 
     def test_update_or_create_with_unique_constraint(self):
-        self.assertFalse(UniqueConstraintSoftDeleteModel.has_unique_fields())
         # Create and soft-delete object
         obj, created = UniqueConstraintSoftDeleteModel.objects.update_or_create(name='thor', team='avengers')
         obj.delete()
         # Update it and see if it fails
-        self.assertFalse(UniqueTogetherSoftDeleteModel.objects.all())  # empty
-        obj, created = UniqueTogetherSoftDeleteModel.objects.update_or_create(name='thor', team='avengers')
+        obj, created = UniqueConstraintSoftDeleteModel.objects.update_or_create(name='thor', team='avengers', defaults={})
         self.assertEqual(obj.name, 'thor')
         self.assertEqual(obj.team, 'avengers')
         self.assertFalse(created)
+        self.assertTrue(UniqueConstraintSoftDeleteModel.has_unique_fields())
 
     def test_update_or_create_with_unique_together_constraint(self):
         # Create and soft-delete object

--- a/safedelete/tests/test_soft_delete.py
+++ b/safedelete/tests/test_soft_delete.py
@@ -176,7 +176,6 @@ class SoftDeleteTestCase(SafeDeleteForceTestCase):
         self.assertEqual(obj.name, 'thor')
         self.assertEqual(obj.team, 'avengers')
         self.assertFalse(created)
-        self.assertTrue(UniqueConstraintSoftDeleteModel.has_unique_fields())
 
     def test_update_or_create_with_unique_together_constraint(self):
         # Create and soft-delete object
@@ -187,7 +186,11 @@ class SoftDeleteTestCase(SafeDeleteForceTestCase):
         self.assertEqual(obj.name, 'thor')
         self.assertEqual(obj.team, 'avengers')
         self.assertFalse(created)
+
+    def test_model_has_unique_fields():
+        self.assertTrue(UniqueSoftDeleteModel.has_unique_fields())
         self.assertTrue(UniqueTogetherSoftDeleteModel.has_unique_fields())
+        self.assertTrue(UniqueConstraintSoftDeleteModel.has_unique_fields())
 
     @override_settings(SAFE_DELETE_INTERPRET_UNDELETED_OBJECTS_AS_CREATED=True)
     def test_update_or_create_flag_with_settings_flag_active(self):

--- a/safedelete/tests/test_soft_delete.py
+++ b/safedelete/tests/test_soft_delete.py
@@ -34,6 +34,20 @@ class UniqueSoftDeleteModel(SafeDeleteModel):
     )
 
 
+class UniqueConstraintSoftDeleteModel(SafeDeleteModel):
+
+    name = models.CharField(max_length=100)
+    team = models.CharField(max_length=100)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["name", "team"],
+                name="unique_constraint",
+            )
+        ]
+
+
 class UniqueTogetherSoftDeleteModel(SoftDeleteModel):
 
     name = models.CharField(max_length=100)
@@ -153,6 +167,18 @@ class SoftDeleteTestCase(SafeDeleteForceTestCase):
         self.assertEqual(obj.name, 'unique-test')
         self.assertEqual(created, False)
 
+    def test_update_or_create_with_unique_constraint(self):
+        self.assertFalse(UniqueConstraintSoftDeleteModel.has_unique_fields())
+        # Create and soft-delete object
+        obj, created = UniqueConstraintSoftDeleteModel.objects.update_or_create(name='thor', team='avengers')
+        obj.delete()
+        # Update it and see if it fails
+        self.assertFalse(UniqueTogetherSoftDeleteModel.objects.all())  # empty
+        obj, created = UniqueTogetherSoftDeleteModel.objects.update_or_create(name='thor', team='avengers')
+        self.assertEqual(obj.name, 'thor')
+        self.assertEqual(obj.team, 'avengers')
+        self.assertFalse(created)
+
     def test_update_or_create_with_unique_together_constraint(self):
         # Create and soft-delete object
         obj, created = UniqueTogetherSoftDeleteModel.objects.update_or_create(name='thor', team='avengers')
@@ -161,7 +187,8 @@ class SoftDeleteTestCase(SafeDeleteForceTestCase):
         obj, created = UniqueTogetherSoftDeleteModel.objects.update_or_create(name='thor', team='avengers')
         self.assertEqual(obj.name, 'thor')
         self.assertEqual(obj.team, 'avengers')
-        self.assertEqual(created, False)
+        self.assertFalse(created)
+        self.assertTrue(UniqueTogetherSoftDeleteModel.has_unique_fields())
 
     @override_settings(SAFE_DELETE_INTERPRET_UNDELETED_OBJECTS_AS_CREATED=True)
     def test_update_or_create_flag_with_settings_flag_active(self):

--- a/safedelete/tests/test_soft_delete.py
+++ b/safedelete/tests/test_soft_delete.py
@@ -187,7 +187,7 @@ class SoftDeleteTestCase(SafeDeleteForceTestCase):
         self.assertEqual(obj.team, 'avengers')
         self.assertFalse(created)
 
-    def test_model_has_unique_fields():
+    def test_model_has_unique_fields(self):
         self.assertTrue(UniqueSoftDeleteModel.has_unique_fields())
         self.assertTrue(UniqueTogetherSoftDeleteModel.has_unique_fields())
         self.assertTrue(UniqueConstraintSoftDeleteModel.has_unique_fields())


### PR DESCRIPTION
Found a bug where model.has_unique_fields() returns False for a model with a UniqueConstraint

My proposed fix is contained in the first commit, but commented out (Edit: uncommented in final code)

~~When attempting to write up a test, however, update_or_create was returning created=True, where I expected False.~~

~~Steps:~~
~~- create object~~
~~- delete object~~
~~- update or create same object~~
~~- expected False, returns True~~

~~has_unique_fields returns False, so there shouldn't even be a way to enter the code block where created gets set to true.~~

~~Can anyone help me figure this out?~~