### PR TITLE
Add pendingdeprecationwarning, if desired

### DIFF
--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -197,6 +197,10 @@ class SafeDeleteModel(models.Model):
             model: Model instance to check
         """
         if cls._meta.unique_together:
+            warnings.warn(
+                'models.UniqueConstraint is recommended over unique_together',
+                 PendingDeprecationWarning
+            )
             return True
 
         for field in cls._meta.fields:

--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -199,7 +199,7 @@ class SafeDeleteModel(models.Model):
         if cls._meta.unique_together:
             warnings.warn(
                 'models.UniqueConstraint is recommended over unique_together',
-                 PendingDeprecationWarning
+                PendingDeprecationWarning
             )
             return True
 


### PR DESCRIPTION
https://docs.djangoproject.com/en/3.2/ref/models/options/#unique-together

>unique_together may be deprecated in the future.

Can't hurt to get ahead of the game

This is really a PR on top of #179--I wouldn't add a warning to switch code to a known bug--but I can't make it a pull request to that branch within safedelete repo