### PR TITLE
Alert user when uniqueness violated by deleted object

### DIFF
--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -254,7 +254,7 @@ class SafeDeleteModel(models.Model):
             if len(unique_check) != len(lookup_kwargs):
                 continue
 
-            # This is the changed line
+            # This is the first changed line
             if hasattr(model_class, 'all_objects'):
                 qs = model_class.all_objects.filter(**lookup_kwargs)
             else:
@@ -271,6 +271,12 @@ class SafeDeleteModel(models.Model):
             if not self._state.adding and model_class_pk is not None:
                 qs = qs.exclude(pk=model_class_pk)
             if qs.exists():
+                # This conditional clause has also been added
+                if FIELD_NAME not in lookup_kwargs:
+                    qs.filter(**{FIELD_NAME: None})
+                    if not qs.exists():
+                        # raise exception that existing deleted model has unique check conflict
+                        continue
                 if len(unique_check) == 1:
                     key = unique_check[0]
                 else:

--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -227,6 +227,7 @@ class SafeDeleteModel(models.Model):
     # against "deleted" (but still in db) objects.
     # FIXME: Better/cleaner way ?
     def _perform_unique_checks(self, unique_checks):
+        raise NotImplementedError()
         errors = {}
 
         for model_class, unique_check in unique_checks:


### PR DESCRIPTION
Re-reading your comments in #185, I have understood that raising an error can be done in the normal model, but reviving existing deleted objects on `create()` would be a separate model (as opposed to a flag). Please let me know if I have misunderstood.

As far as the code, I present two options:
1) Check from within `_perform_unique_checks()` if uniqueness is violated by a deleted object
2) Wrap Django's `create()` class with some custom code to perform the same uniqueness check

The advantage of option 1 is that it's a universal check for all use cases, not just `create()`.

The advantage of option 2 is that if the one changed line in safedelete's `_perform_unique_checks()` can ever be simplified, safedelete won't have to maintain the rest of the Django method.

Both options make one additional query to the database.

I am partial to option 2 for maintainability. Let me know your thoughts.

(Will add tests once path has been finalized.)