### PR TITLE
Fixed MANIFEST.in: Added py.typed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include *.rst
+include safedelete/py.typed
 include LICENSE AUTHORS CHANGES
 recursive-include safedelete/templates *.html
 recursive-include safedelete/static *.css *.js *.jpg *.jpeg *.png

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
 [metadata]
 description-file = README.rst
-
-[options.package_data]
-{name} = py.typed


### PR DESCRIPTION
turns out that adding py.typed to the setup.cfg didn't acutally worked out.

Sorry about that the confusion. 

Signed-off-by: Sebastian Wagner <sebastian@inter.link>