### PR TITLE
Fix argument type passed to db_for_write

### DIFF
--- a/safedelete/utils.py
+++ b/safedelete/utils.py
@@ -13,7 +13,7 @@ def related_objects(obj, only_deleted_by_cascade=False):
         only_deleted_by_cascade: Include filter in flatten method to bypass elements controling undelete cascading.
     """
 
-    collector = NestedObjects(using=router.db_for_write(obj))
+    collector = NestedObjects(using=router.db_for_write(type(obj)))
     collector.collect([obj])
 
     def flatten(elem):


### PR DESCRIPTION
As stated in [django docs](https://docs.djangoproject.com/en/4.1/topics/db/multi-db/#db_for_write), `model` argument passed to `router.db_for_write` method should be model type, not instance. I fixed this issue in `related_objects` function.