### PR TITLE
Fix SafeDeleteQueryset.as_manager to return SafeDeleteManager

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ CHANGELOG
 - Fix de translation
 - Fix argument type passed to db_for_write #222
 - Django 4.2 support #223
+- Fix SafeDeleteQueryset.as_manager() now returns SafeDeleteManager
 
 1.3.1 (2022-10-03)
 ==================

--- a/safedelete/queryset.py
+++ b/safedelete/queryset.py
@@ -29,6 +29,18 @@ class SafeDeleteQueryset(query.QuerySet):
         super(SafeDeleteQueryset, self).__init__(model=model, query=query, using=using, hints=hints)
         self.query: SafeDeleteQuery = query or SafeDeleteQuery(self.model)
 
+    @classmethod
+    def as_manager(cls):
+        """Override as_manager behavior to ensure we create a SafeDeleteManager.
+        """
+        # Address the circular dependency between `SafeDeleteQueryset` and `SafeDeleteManager`.
+        from .managers import SafeDeleteManager
+
+        manager = SafeDeleteManager.from_queryset(cls)()
+        manager._built_with_as_manager = True
+        return manager
+    as_manager.queryset_only = True  # type: ignore
+
     def delete(self, force_policy: Optional[int] = None) -> Tuple[int, Dict[str, int]]:
         """Overrides bulk delete behaviour.
 

--- a/safedelete/tests/test_custom_queryset.py
+++ b/safedelete/tests/test_custom_queryset.py
@@ -82,6 +82,13 @@ class CustomQuerySetTestCase(SafeDeleteTestCase):
         # and they can be custom filtered
         self.assertEqual(deleted_only.green().count(), 1)
 
+    def test_custom_queryset_as_manager_is_safedelete(self):
+        """Test whether SafeDeleteQueryset as_manager works as intended
+        """
+        manager = CustomQuerySet.as_manager()
+        self.assertIsInstance(manager, SafeDeleteManager)
+        self.assertFalse(hasattr(manager, 'as_manager'))
+
     @staticmethod
     def _create_green_instance():
         """Shortcut for creating instance with ``color == green``


### PR DESCRIPTION
Calling the as_manager method on a SafeDeleteQueryset subclass previously created a SafeDelete naive manager. This commit overrides the as_manager method to properly return a SafeDeleteManager object.