### PR TITLE
Update ci for Django 4.2

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,9 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        django_version: [ '3.2', '4.0', '4.1', '4.2a1' ]
-        python_version: [ '3.7', '3.8', '3.9', '3.10' ]
+        django_version: [ '3.2', '4.0', '4.1', '4.2' ]
+        python_version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
         exclude:
+          - django_version: '3.2'
+            python_version: '3.11'
+
+          - django_version: '4.0'
+            python_version: '3.11'
+
+          - django_version: '4.1'
+            python_version: '3.11'
 
           - django_version: '4.0'
             python_version: '3.7'
@@ -21,7 +29,7 @@ jobs:
           - django_version: '4.1'
             python_version: '3.7'
 
-          - django_version: '4.2a1'
+          - django_version: '4.2'
             python_version: '3.7'
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -43,7 +51,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .
         pip install -U flake8 coveralls argparse mypy django-stubs types-setuptools
-        pip install -U Django~=${{ matrix.django_version }} --pre
+        pip install -U Django~=${{ matrix.django_version }}
     - name: Lint with flake8
       run: |
         flake8 --ignore=E501,W504 safedelete

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,7 @@ Current branch (1.3.x) is tested with :
 *  Django 3.2 using python 3.7 to 3.10.
 *  Django 4.0 using python 3.8 to 3.10.
 *  Django 4.1 using python 3.8 to 3.10.
+*  Django 4.2 using python 3.8 to 3.11.
 
 
 Installation


### PR DESCRIPTION
Now that [Django 4.2 is released](https://www.djangoproject.com/weblog/2023/apr/03/django-42-released/) we can remove the test against the alpha version.

Is there a plan when there will be a release to pypi? (no rush just curious :+1: ) 