### PR TITLE
adding check for nullity in related models delete

### DIFF
--- a/safedelete/models.py
+++ b/safedelete/models.py
@@ -234,8 +234,10 @@ class SafeDeleteModel(models.Model):
         deleted_counter: Counter = Counter()
         for related in related_objects(self):
             if is_safedelete_cls(related.__class__) and not getattr(related, FIELD_NAME):
-                _, delete_response = related.delete(force_policy=SOFT_DELETE, is_cascade=True, **kwargs)
-                deleted_counter.update(delete_response)
+                res = related.delete(force_policy=SOFT_DELETE, is_cascade=True, **kwargs)
+                if res is not None:
+                    _, delete_response = res
+                    deleted_counter.update(delete_response)
 
         # soft-delete the object
         _, delete_response = self._delete(force_policy=SOFT_DELETE, **kwargs)

--- a/safedelete/queryset.py
+++ b/safedelete/queryset.py
@@ -61,8 +61,10 @@ class SafeDeleteQueryset(query.QuerySet):
             deleted_counter: Counter = Counter()
             # TODO: Replace this by bulk update if we can
             for obj in self.all():
-                _, delete_response = obj.delete(force_policy=force_policy)
-                deleted_counter.update(delete_response)
+                res = obj.delete(force_policy=force_policy)
+                if res is not None:
+                    _, delete_response = res
+                    deleted_counter.update(delete_response)                
             self._result_cache = None
             return sum(deleted_counter.values()), dict(deleted_counter)
     delete.alters_data = True  # type: ignore


### PR DESCRIPTION
When related models are deleted, the block of code here around models.py:234 gives the error:

  File "/workspaces/project/.venv/lib/python3.9/site-packages/safedelete/models.py", line 246, in soft_delete_cascade_policy_action
    _, delete_response = res
TypeError: cannot unpack non-iterable NoneType object

Based on the context, seems like this bug comes about because the original object that is being deleted appears in the related_objects(self) function.

```        
      deleted_counter: Counter = Counter()
        for related in related_objects(self):
            if is_safedelete_cls(related.__class__) and not getattr(related, FIELD_NAME):
                res = related.delete(force_policy=SOFT_DELETE, is_cascade=True, **kwargs)
                if res is not None:
                    _, delete_response = res
                    deleted_counter.update(delete_response)
```

This issue appeared in django = "4.1.7", the latest version of django-safedelete as well as 1.3.3. Python version is Python 3.9.20. This is the exact bug in https://github.com/makinacorpus/django-safedelete/issues/235

