### PR TITLE
[documentation] Three NOT Two Signals in signals.rst

### DIFF
--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -8,7 +8,7 @@ Signals
 Signals
 -------
 
-There are two signals available. Please refer to the `Django signals <https://docs.djangoproject.com/en/dev/topics/signals/>`_ documentation on how to use them.
+There are three signals available. Please refer to the `Django signals <https://docs.djangoproject.com/en/dev/topics/signals/>`_ documentation on how to use them.
 
 .. py:data:: safedelete.signals.pre_softdelete
 


### PR DESCRIPTION
The documentation clearly lists three (3) signals but it says two signals; I've simply suggested one way to make it compliant.

I have not checked if there really are 1, 2, 3 or N signals - only changed the wording to be congruent.

DSL